### PR TITLE
[FEAT/#5] 도메인 불변 객체 이관 및 공통 엔티티 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 
 	implementation("org.springframework.retry:spring-retry")
 	implementation("com.fasterxml.jackson.core:jackson-databind:${property("jacksonDataBindVersion")}")

--- a/src/main/java/sopt/makers/authentication/AuthenticationApplication.java
+++ b/src/main/java/sopt/makers/authentication/AuthenticationApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.*;
 
 @SpringBootApplication(scanBasePackages = {"sopt.makers.authentication"})
-@EnableJpaAuditing
 public class AuthenticationApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/sopt/makers/authentication/AuthenticationApplication.java
+++ b/src/main/java/sopt/makers/authentication/AuthenticationApplication.java
@@ -2,8 +2,10 @@ package sopt.makers.authentication;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.*;
 
 @SpringBootApplication(scanBasePackages = {"sopt.makers.authentication"})
+@EnableJpaAuditing
 public class AuthenticationApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/sopt/makers/authentication/database/cache/info.txt
+++ b/src/main/java/sopt/makers/authentication/database/cache/info.txt
@@ -1,0 +1,1 @@
+cache package

--- a/src/main/java/sopt/makers/authentication/database/core/common/BaseTimeEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/common/BaseTimeEntity.java
@@ -1,0 +1,18 @@
+package sopt.makers.authentication.database.core.common;
+
+import jakarta.persistence.*;
+import java.time.*;
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.jpa.domain.support.*;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate private LocalDateTime updatedAt;
+}

--- a/src/main/java/sopt/makers/authentication/database/core/common/BaseTimeEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/common/BaseTimeEntity.java
@@ -1,10 +1,13 @@
 package sopt.makers.authentication.database.core.common;
 
-import jakarta.persistence.*;
 import java.time.*;
-import lombok.*;
+
+import jakarta.persistence.*;
+
 import org.springframework.data.annotation.*;
 import org.springframework.data.jpa.domain.support.*;
+
+import lombok.*;
 
 @Getter
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/sopt/makers/authentication/database/core/entity/PhoneVerification.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/PhoneVerification.java
@@ -1,11 +1,9 @@
 package sopt.makers.authentication.database.core.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 
 @Entity
+@Table(name = "phone_verifications")
 public class PhoneVerification {
 
   @Id

--- a/src/main/java/sopt/makers/authentication/database/core/entity/PhoneVerification.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/PhoneVerification.java
@@ -1,6 +1,10 @@
 package sopt.makers.authentication.database.core.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "phone_verifications")

--- a/src/main/java/sopt/makers/authentication/database/core/entity/PhoneVerification.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/PhoneVerification.java
@@ -1,4 +1,4 @@
-package sopt.makers.authentication.database.entity;
+package sopt.makers.authentication.database.core.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
@@ -1,6 +1,10 @@
 package sopt.makers.authentication.database.core.entity;
 
-import sopt.makers.authentication.domain.auth.*;
+import sopt.makers.authentication.domain.auth.Activity;
+import sopt.makers.authentication.domain.auth.Part;
+import sopt.makers.authentication.domain.auth.Role;
+import sopt.makers.authentication.domain.auth.Team;
+import sopt.makers.authentication.domain.auth.User;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
@@ -29,9 +29,9 @@ public class UserActivityHistoryEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @NotNull
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
-  @NotNull
   private UserEntity user;
 
   @Min(1)

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
@@ -1,0 +1,48 @@
+package sopt.makers.authentication.database.core.entity;
+
+import sopt.makers.authentication.domain.auth.*;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "USER_ACTIVITY_HISTORIES")
+public class UserActivityHistoryEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  @NotNull
+  private UserEntity user;
+
+  @Min(1)
+  private int generation;
+
+  @Enumerated(EnumType.STRING)
+  private Team team;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private Part part;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
+  public UserActivityHistoryEntity(final UserEntity user, final Activity activity) {
+    this.user = user;
+    this.generation = activity.generation();
+    this.team = activity.team();
+    this.part = activity.part();
+    this.role = activity.role();
+  }
+
+  public Activity toDomain() {
+    return new Activity(generation, team, part);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
@@ -1,11 +1,25 @@
 package sopt.makers.authentication.database.core.entity;
 
-import sopt.makers.authentication.domain.auth.*;
+import sopt.makers.authentication.domain.auth.Activity;
+import sopt.makers.authentication.domain.auth.Part;
+import sopt.makers.authentication.domain.auth.Role;
+import sopt.makers.authentication.domain.auth.Team;
 
-import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
@@ -1,9 +1,6 @@
 package sopt.makers.authentication.database.core.entity;
 
-import sopt.makers.authentication.domain.auth.Activity;
-import sopt.makers.authentication.domain.auth.Part;
-import sopt.makers.authentication.domain.auth.Role;
-import sopt.makers.authentication.domain.auth.Team;
+import sopt.makers.authentication.domain.auth.*;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -48,15 +45,30 @@ public class UserActivityHistoryEntity {
   @Enumerated(EnumType.STRING)
   private Role role;
 
-  public UserActivityHistoryEntity(final UserEntity user, final Activity activity) {
+  private UserActivityHistoryEntity(
+      final UserEntity user,
+      final int generation,
+      final Team team,
+      final Part part,
+      final Role role) {
     this.user = user;
-    this.generation = activity.generation();
-    this.team = activity.team();
-    this.part = activity.part();
-    this.role = activity.role();
+    this.generation = generation;
+    this.team = team;
+    this.part = part;
+    this.role = role;
+  }
+
+  public static UserActivityHistoryEntity fromDomain(final User user, final Activity activity) {
+    UserEntity userEntity = UserEntity.fromDomain(user);
+    return new UserActivityHistoryEntity(
+        userEntity,
+        activity.generation(),
+        activity.team().orElse(null),
+        activity.part().orElse(null),
+        activity.role());
   }
 
   public Activity toDomain() {
-    return new Activity(generation, team, part);
+    return Activity.of(generation, team, part, role);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserActivityHistoryEntity.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "USER_ACTIVITY_HISTORIES")
+@Table(name = "user_activity_histories")
 public class UserActivityHistoryEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -17,7 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
-import org.hibernate.annotations.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import lombok.*;
 

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -19,8 +19,7 @@ import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.*;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -32,8 +31,8 @@ public class UserEntity extends BaseTimeEntity {
 
   @NotNull String name;
   @NotNull String phone;
-  @NotNull String email;
-  @NotNull LocalDate birthday;
+  String email;
+  LocalDate birthday;
   @NotNull String authPlatformId;
 
   @NotNull
@@ -44,15 +43,39 @@ public class UserEntity extends BaseTimeEntity {
   @ColumnDefault(value = "false")
   Boolean isActive;
 
-  public UserEntity(final User user, boolean isActive) {
+  private UserEntity(
+      long id,
+      String name,
+      String phone,
+      String email,
+      LocalDate birthday,
+      String authPlatformId,
+      AuthPlatform authPlatformType) {
+    this.id = id;
+    this.name = name;
+    this.phone = phone;
+    this.email = email;
+    this.birthday = birthday;
+    this.authPlatformId = authPlatformId;
+    this.authPlatformType = authPlatformType;
+  }
+
+  public static UserEntity fromDomain(final User user) {
     Profile profile = user.getProfile();
     SocialAccount socialAccount = user.getSocialAccount();
+    return new UserEntity(
+        user.getId(),
+        profile.name(),
+        profile.phone(),
+        profile.email(),
+        profile.birthday(),
+        socialAccount.authPlatformId(),
+        socialAccount.authPlatformType());
+  }
 
-    this.name = profile.name();
-    this.phone = profile.phone();
-    this.email = profile.email();
-    this.birthday = profile.birthday();
-    this.authPlatformId = socialAccount.authPlatformId();
-    this.authPlatformType = socialAccount.authPlatformType();
+  public User toDomain() {
+    SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType.name());
+    Profile profile = Profile.of(name, email, phone, birthday);
+    return User.createNewUser(id, socialAccount, profile);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -68,7 +68,7 @@ public class UserEntity extends BaseTimeEntity {
         profile.name(),
         profile.phone(),
         profile.email().orElse(null),
-        profile.birthday().orElse(null),
+        profile.birthday(),
         socialAccount.authPlatformId(),
         socialAccount.authPlatformType());
   }

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -1,0 +1,42 @@
+package sopt.makers.authentication.database.core.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import java.time.*;
+import lombok.*;
+import sopt.makers.authentication.database.core.common.*;
+import sopt.makers.authentication.domain.auth.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "USERS")
+public class UserEntity extends BaseTimeEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotNull String name;
+  @NotNull String phone;
+  @NotNull String email;
+  @NotNull LocalDate birthday;
+  @NotNull String authPlatformId;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  AuthPlatform authPlatformType;
+
+  @NotNull Boolean isActive;
+
+  public UserEntity(final User user, boolean isActive) {
+    Profile profile = user.getProfile();
+    SocialAccount socialAccount = user.getSocialAccount();
+
+    this.name = profile.name();
+    this.phone = profile.phone();
+    this.email = profile.email();
+    this.birthday = profile.birthday();
+    this.authPlatformId = socialAccount.authPlatformId();
+    this.authPlatformType = socialAccount.authPlatformType();
+    this.isActive = isActive;
+  }
+}

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -1,14 +1,24 @@
 package sopt.makers.authentication.database.core.entity;
 
-import sopt.makers.authentication.database.core.common.*;
-import sopt.makers.authentication.domain.auth.*;
+import sopt.makers.authentication.database.core.common.BaseTimeEntity;
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+import sopt.makers.authentication.domain.auth.Profile;
+import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.auth.User;
 
-import java.time.*;
+import java.time.LocalDate;
 
-import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -7,6 +7,7 @@ import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.auth.User;
 
 import java.time.LocalDate;
+import java.util.*;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -44,7 +45,7 @@ public class UserEntity extends BaseTimeEntity {
   Boolean isActive;
 
   private UserEntity(
-      long id,
+      Long id,
       String name,
       String phone,
       String email,

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -67,8 +67,8 @@ public class UserEntity extends BaseTimeEntity {
         user.getId(),
         profile.name(),
         profile.phone(),
-        profile.email(),
-        profile.birthday(),
+        profile.email().orElse(null),
+        profile.birthday().orElse(null),
         socialAccount.authPlatformId(),
         socialAccount.authPlatformType());
   }

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -1,11 +1,14 @@
 package sopt.makers.authentication.database.core.entity;
 
-import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
-import java.time.*;
-import lombok.*;
 import sopt.makers.authentication.database.core.common.*;
 import sopt.makers.authentication.domain.auth.*;
+
+import java.time.*;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -23,7 +23,7 @@ import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "USERS")
+@Table(name = "users")
 public class UserEntity extends BaseTimeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserEntity.java
@@ -17,6 +17,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
+import org.hibernate.annotations.*;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -38,7 +40,9 @@ public class UserEntity extends BaseTimeEntity {
   @Enumerated(EnumType.STRING)
   AuthPlatform authPlatformType;
 
-  @NotNull Boolean isActive;
+  @NotNull
+  @ColumnDefault(value = "false")
+  Boolean isActive;
 
   public UserEntity(final User user, boolean isActive) {
     Profile profile = user.getProfile();
@@ -50,6 +54,5 @@ public class UserEntity extends BaseTimeEntity {
     this.birthday = profile.birthday();
     this.authPlatformId = socialAccount.authPlatformId();
     this.authPlatformType = socialAccount.authPlatformType();
-    this.isActive = isActive;
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserRegisterInfoEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserRegisterInfoEntity.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "USER_REGISTER_INFOS")
+@Table(name = "user_register_infos")
 public class UserRegisterInfoEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserRegisterInfoEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserRegisterInfoEntity.java
@@ -1,0 +1,30 @@
+package sopt.makers.authentication.database.core.entity;
+
+import sopt.makers.authentication.domain.auth.*;
+
+import java.time.*;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "USER_REGISTER_INFOS")
+public class UserRegisterInfoEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotNull private String name;
+  @NotNull private String phone;
+  @NotNull private LocalDate birthday;
+
+  @Min(1)
+  private int generation;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private Part part;
+}

--- a/src/main/java/sopt/makers/authentication/database/core/entity/UserRegisterInfoEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/core/entity/UserRegisterInfoEntity.java
@@ -1,13 +1,21 @@
 package sopt.makers.authentication.database.core.entity;
 
-import sopt.makers.authentication.domain.auth.*;
+import sopt.makers.authentication.domain.auth.Part;
 
-import java.time.*;
+import java.time.LocalDate;
 
-import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/sopt/makers/authentication/database/core/repository/VerificationRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/core/repository/VerificationRepositoryImpl.java
@@ -1,4 +1,4 @@
-package sopt.makers.authentication.database.repository;
+package sopt.makers.authentication.database.core.repository;
 
 import sopt.makers.authentication.usecase.auth.port.out.VerificationRepository;
 

--- a/src/main/java/sopt/makers/authentication/domain/auth/Activity.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Activity.java
@@ -1,17 +1,23 @@
 package sopt.makers.authentication.domain.auth;
 
-public record Activity(int generation, Team team, Part part, Role role) {
+import java.util.*;
 
-  public Activity(int generation, final Team team, final Part part) {
-    this(generation, team, part, Role.MEMBER);
+import jakarta.validation.constraints.*;
+
+public record Activity(
+    int generation, Optional<Team> team, Optional<Part> part, @NotNull Role role) {
+
+  public static Activity of(int generation, final Team team, final Part part) {
+    return new Activity(
+        generation, Optional.ofNullable(team), Optional.ofNullable(part), Role.MEMBER);
+  }
+
+  public static Activity of(int generation, final Team team, final Part part, final Role role) {
+    return new Activity(generation, Optional.ofNullable(team), Optional.ofNullable(part), role);
   }
 
   public void validateActivityContentsEmpty() {
-    if (this.role == null) {
-      throw new IllegalArgumentException("활동 정보가 비어있습니다.");
-    }
-
-    if (this.role.isPartRequired() && this.part == null) {
+    if (this.role.isPartRequired() && this.part.isEmpty()) {
       throw new IllegalArgumentException("해당 Role은 part 필드가 필수입니다.");
     }
   }

--- a/src/main/java/sopt/makers/authentication/domain/auth/Activity.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Activity.java
@@ -1,0 +1,18 @@
+package sopt.makers.authentication.domain.auth;
+
+public record Activity(int generation, Team team, Part part, Role role) {
+
+  public Activity(int generation, final Team team, final Part part) {
+    this(generation, team, part, Role.MEMBER);
+  }
+
+  public void validateActivityContentsEmpty() {
+    if (this.role == null) {
+      throw new IllegalArgumentException("활동 정보가 비어있습니다.");
+    }
+
+    if (this.role.isPartRequired() && this.part == null) {
+      throw new IllegalArgumentException("해당 Role은 part 필드가 필수입니다.");
+    }
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/Activity.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Activity.java
@@ -21,7 +21,9 @@ public record Activity(
   }
 
   public void validateActivityContentsEmpty() {
-    if (this.role.isPartRequired() && this.part.isEmpty()) {
+    boolean isActivityContentsEmpty = this.role.isPartRequired() && this.part.isEmpty();
+
+    if (isActivityContentsEmpty) {
       throw new DomainException(ROLE_REQUIRES_PART);
     }
   }

--- a/src/main/java/sopt/makers/authentication/domain/auth/Activity.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Activity.java
@@ -1,8 +1,12 @@
 package sopt.makers.authentication.domain.auth;
 
-import java.util.*;
+import static sopt.makers.authentication.support.common.code.failure.DomainFailure.ROLE_REQUIRES_PART;
 
-import jakarta.validation.constraints.*;
+import sopt.makers.authentication.support.common.exception.DomainException;
+
+import java.util.Optional;
+
+import jakarta.validation.constraints.NotNull;
 
 public record Activity(
     int generation, Optional<Team> team, Optional<Part> part, @NotNull Role role) {
@@ -18,7 +22,7 @@ public record Activity(
 
   public void validateActivityContentsEmpty() {
     if (this.role.isPartRequired() && this.part.isEmpty()) {
-      throw new IllegalArgumentException("해당 Role은 part 필드가 필수입니다.");
+      throw new DomainException(ROLE_REQUIRES_PART);
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
@@ -46,7 +46,7 @@ public class ActivityList {
         .filter(a -> a.equals(activity))
         .findAny()
         .ifPresent(
-            a -> {
+            existActivity -> {
               throw new DomainException(DUPLICATE_ACTIVITY);
             });
   }

--- a/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.domain.auth;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ActivityList {
 

--- a/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
@@ -3,21 +3,21 @@ package sopt.makers.authentication.domain.auth;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ActivityList {
+import jakarta.validation.constraints.*;
 
+import lombok.*;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ActivityList {
   private final List<Activity> activities;
 
   public ActivityList() {
     this.activities = new ArrayList<>();
   }
 
-  public ActivityList(final List<Activity> activityList) {
-    this.activities = activityList;
-  }
-
-  public ActivityList addActivity(final Activity activity) {
+  public ActivityList addActivity(@NotNull final Activity activity) {
     validateActivityDuplication(activity);
-    validateActivityEmpty(activity);
     List<Activity> updatedActivities = new ArrayList<>(this.activities);
     updatedActivities.add(activity);
     return new ActivityList(updatedActivities);
@@ -43,12 +43,5 @@ public class ActivityList {
             a -> {
               throw new IllegalArgumentException("이미 존재하는 활동 정보입니다.");
             });
-  }
-
-  private void validateActivityEmpty(final Activity activity) {
-    if (activity == null) {
-      throw new IllegalArgumentException("활동이 비어있습니다.");
-    }
-    activity.validateActivityContentsEmpty();
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
@@ -1,0 +1,53 @@
+package sopt.makers.authentication.domain.auth;
+
+import java.util.*;
+
+public class ActivityList {
+
+  private final List<Activity> activities;
+
+  public ActivityList() {
+    this.activities = new ArrayList<>();
+  }
+
+  public ActivityList(final List<Activity> activityList) {
+    this.activities = activityList;
+  }
+
+  public ActivityList addActivity(final Activity activity) {
+    validateActivityDuplication(activity);
+    validateActivityEmpty(activity);
+    List<Activity> updatedActivities = new ArrayList<>(this.activities);
+    updatedActivities.add(activity);
+    return new ActivityList(updatedActivities);
+  }
+
+  public Activity getFirstActivity() {
+    return activities.getFirst();
+  }
+
+  public Activity getLastActivity() {
+    return activities.getLast();
+  }
+
+  public int getTotalActivitySize() {
+    return activities.size();
+  }
+
+  private void validateActivityDuplication(final Activity activity) {
+    activities.stream()
+        .filter(a -> a.equals(activity))
+        .findAny()
+        .ifPresent(
+            a -> {
+              throw new IllegalArgumentException("이미 존재하는 활동 정보입니다.");
+            });
+  }
+
+  private void validateActivityEmpty(final Activity activity) {
+    if (activity == null) {
+      throw new IllegalArgumentException("활동이 비어있습니다.");
+    }
+    activity.validateActivityContentsEmpty();
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/ActivityList.java
@@ -1,11 +1,17 @@
 package sopt.makers.authentication.domain.auth;
 
+import static sopt.makers.authentication.support.common.code.failure.DomainFailure.DUPLICATE_ACTIVITY;
+
+import sopt.makers.authentication.support.common.exception.DomainException;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotNull;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -41,7 +47,7 @@ public class ActivityList {
         .findAny()
         .ifPresent(
             a -> {
-              throw new IllegalArgumentException("이미 존재하는 활동 정보입니다.");
+              throw new DomainException(DUPLICATE_ACTIVITY);
             });
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/AuthPlatform.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/AuthPlatform.java
@@ -1,6 +1,6 @@
 package sopt.makers.authentication.domain.auth;
 
-import java.util.*;
+import java.util.Arrays;
 
 public enum AuthPlatform {
   GOOGLE,

--- a/src/main/java/sopt/makers/authentication/domain/auth/AuthPlatform.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/AuthPlatform.java
@@ -1,5 +1,9 @@
 package sopt.makers.authentication.domain.auth;
 
+import static sopt.makers.authentication.support.common.code.failure.DomainFailure.INVALID_SOCIAL_PLATFORM;
+
+import sopt.makers.authentication.support.common.exception.DomainException;
+
 import java.util.Arrays;
 
 public enum AuthPlatform {
@@ -11,6 +15,6 @@ public enum AuthPlatform {
     return Arrays.stream(AuthPlatform.values())
         .filter(p -> p.name().equals(platform))
         .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 소셜 플랫폼입니다 : " + platform));
+        .orElseThrow(() -> new DomainException(INVALID_SOCIAL_PLATFORM));
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/AuthPlatform.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/AuthPlatform.java
@@ -1,0 +1,16 @@
+package sopt.makers.authentication.domain.auth;
+
+import java.util.*;
+
+public enum AuthPlatform {
+  GOOGLE,
+  APPLE;
+
+  public static AuthPlatform find(final String platform) {
+
+    return Arrays.stream(AuthPlatform.values())
+        .filter(p -> p.name().equals(platform))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 소셜 플랫폼입니다 : " + platform));
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/Part.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Part.java
@@ -1,6 +1,6 @@
 package sopt.makers.authentication.domain.auth;
 
-import java.util.*;
+import java.util.Arrays;
 
 public enum Part {
   ANDROID,

--- a/src/main/java/sopt/makers/authentication/domain/auth/Part.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Part.java
@@ -1,0 +1,20 @@
+package sopt.makers.authentication.domain.auth;
+
+import java.util.*;
+
+public enum Part {
+  ANDROID,
+  IOS,
+  SERVER,
+  DESIGN,
+  PLAN,
+  WEB;
+
+  public static Part findPart(final String part) {
+
+    return Arrays.stream(Part.values())
+        .filter(p -> p.name().equals(part))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 파트입니다 : " + part));
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/Part.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Part.java
@@ -1,5 +1,8 @@
 package sopt.makers.authentication.domain.auth;
 
+import sopt.makers.authentication.support.common.code.failure.DomainFailure;
+import sopt.makers.authentication.support.common.exception.DomainException;
+
 import java.util.Arrays;
 
 public enum Part {
@@ -15,6 +18,6 @@ public enum Part {
     return Arrays.stream(Part.values())
         .filter(p -> p.name().equals(part))
         .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 파트입니다 : " + part));
+        .orElseThrow(() -> new DomainException(DomainFailure.NOT_FOUND_PART));
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
@@ -1,13 +1,18 @@
 package sopt.makers.authentication.domain.auth;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotNull;
 
 public record Profile(
-    @NotNull String name, @NotNull String email, @NotNull String phone, LocalDate birthday) {
+    @NotNull String name,
+    Optional<String> email,
+    @NotNull String phone,
+    Optional<LocalDate> birthday) {
+
   public static Profile of(String name, String email, String phone, LocalDate birthday) {
-    return new Profile(name, email, phone, birthday);
+    return new Profile(name, Optional.ofNullable(email), phone, Optional.ofNullable(birthday));
   }
 
   public Profile updateName(final String name) {
@@ -15,7 +20,7 @@ public record Profile(
   }
 
   public Profile updateEmail(final String email) {
-    return new Profile(this.name, email, this.phone, this.birthday);
+    return new Profile(this.name, Optional.ofNullable(email), this.phone, this.birthday);
   }
 
   public Profile updatePhone(final String phone) {
@@ -23,6 +28,6 @@ public record Profile(
   }
 
   public Profile updateBirthday(final LocalDate birthday) {
-    return new Profile(this.name, this.email, this.phone, birthday);
+    return new Profile(this.name, this.email, this.phone, Optional.ofNullable(birthday));
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
@@ -1,0 +1,22 @@
+package sopt.makers.authentication.domain.auth;
+
+import java.time.*;
+
+public record Profile(String name, String email, String phone, LocalDate birthday) {
+
+  public Profile updateName(final String name) {
+    return new Profile(name, this.email, this.phone, this.birthday);
+  }
+
+  public Profile updateEmail(final String email) {
+    return new Profile(this.name, email, this.phone, this.birthday);
+  }
+
+  public Profile updatePhone(final String phone) {
+    return new Profile(this.name, this.email, phone, this.birthday);
+  }
+
+  public Profile updateBirthday(final LocalDate birthday) {
+    return new Profile(this.name, this.email, this.phone, birthday);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
@@ -1,6 +1,6 @@
 package sopt.makers.authentication.domain.auth;
 
-import java.time.*;
+import java.time.LocalDate;
 
 public record Profile(String name, String email, String phone, LocalDate birthday) {
 

--- a/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
@@ -2,7 +2,13 @@ package sopt.makers.authentication.domain.auth;
 
 import java.time.LocalDate;
 
-public record Profile(String name, String email, String phone, LocalDate birthday) {
+import jakarta.validation.constraints.*;
+
+public record Profile(
+    @NotNull String name, @NotNull String email, @NotNull String phone, LocalDate birthday) {
+  public static Profile of(String name, String email, String phone, LocalDate birthday) {
+    return new Profile(name, email, phone, birthday);
+  }
 
   public Profile updateName(final String name) {
     return new Profile(name, this.email, this.phone, this.birthday);

--- a/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Profile.java
@@ -9,10 +9,10 @@ public record Profile(
     @NotNull String name,
     Optional<String> email,
     @NotNull String phone,
-    Optional<LocalDate> birthday) {
+    @NotNull LocalDate birthday) {
 
   public static Profile of(String name, String email, String phone, LocalDate birthday) {
-    return new Profile(name, Optional.ofNullable(email), phone, Optional.ofNullable(birthday));
+    return new Profile(name, Optional.ofNullable(email), phone, birthday);
   }
 
   public Profile updateName(final String name) {
@@ -28,6 +28,6 @@ public record Profile(
   }
 
   public Profile updateBirthday(final LocalDate birthday) {
-    return new Profile(this.name, this.email, this.phone, Optional.ofNullable(birthday));
+    return new Profile(this.name, this.email, this.phone, birthday);
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/Role.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Role.java
@@ -1,0 +1,22 @@
+package sopt.makers.authentication.domain.auth;
+
+import java.util.*;
+
+public enum Role {
+  MEMBER,
+  PRESIDENT,
+  VICE_PRESIDENT,
+  TEAM_LEADER,
+  PART_LEADER;
+
+  public static Role findRole(final String role) {
+    return Arrays.stream(Role.values())
+        .filter(r -> r.name().equals(role))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 역할입니다 : " + role));
+  }
+
+  public boolean isPartRequired() {
+    return !(this == PRESIDENT || this == VICE_PRESIDENT);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/Role.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Role.java
@@ -1,5 +1,9 @@
 package sopt.makers.authentication.domain.auth;
 
+import static sopt.makers.authentication.support.common.code.failure.DomainFailure.NOT_FOUND_ROLE;
+
+import sopt.makers.authentication.support.common.exception.DomainException;
+
 import java.util.Arrays;
 
 public enum Role {
@@ -13,7 +17,7 @@ public enum Role {
     return Arrays.stream(Role.values())
         .filter(r -> r.name().equals(role))
         .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 역할입니다 : " + role));
+        .orElseThrow(() -> new DomainException(NOT_FOUND_ROLE));
   }
 
   public boolean isPartRequired() {

--- a/src/main/java/sopt/makers/authentication/domain/auth/Role.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Role.java
@@ -1,6 +1,6 @@
 package sopt.makers.authentication.domain.auth;
 
-import java.util.*;
+import java.util.Arrays;
 
 public enum Role {
   MEMBER,

--- a/src/main/java/sopt/makers/authentication/domain/auth/SocialAccount.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/SocialAccount.java
@@ -1,6 +1,6 @@
 package sopt.makers.authentication.domain.auth;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotNull;
 
 public record SocialAccount(
     @NotNull String authPlatformId, @NotNull AuthPlatform authPlatformType) {

--- a/src/main/java/sopt/makers/authentication/domain/auth/SocialAccount.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/SocialAccount.java
@@ -1,0 +1,19 @@
+package sopt.makers.authentication.domain.auth;
+
+public record SocialAccount(String authPlatformId, AuthPlatform authPlatformType) {
+
+  public static SocialAccount of(final String authPlatformId, final String authPlatformType) {
+    return new SocialAccount(authPlatformId, AuthPlatform.find(authPlatformType));
+  }
+
+  public SocialAccount {
+    validatePlatform(authPlatformId);
+  }
+
+  // 플랫폼 정보가 비어 있는지 검증
+  private void validatePlatform(final String authPlatformId) {
+    if (authPlatformId == null || authPlatformId.isEmpty()) {
+      throw new IllegalArgumentException("빈 플랫폼 정보입니다.");
+    }
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/SocialAccount.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/SocialAccount.java
@@ -1,19 +1,10 @@
 package sopt.makers.authentication.domain.auth;
 
-public record SocialAccount(String authPlatformId, AuthPlatform authPlatformType) {
+import jakarta.validation.constraints.*;
 
+public record SocialAccount(
+    @NotNull String authPlatformId, @NotNull AuthPlatform authPlatformType) {
   public static SocialAccount of(final String authPlatformId, final String authPlatformType) {
     return new SocialAccount(authPlatformId, AuthPlatform.find(authPlatformType));
-  }
-
-  public SocialAccount {
-    validatePlatform(authPlatformId);
-  }
-
-  // 플랫폼 정보가 비어 있는지 검증
-  private void validatePlatform(final String authPlatformId) {
-    if (authPlatformId == null || authPlatformId.isEmpty()) {
-      throw new IllegalArgumentException("빈 플랫폼 정보입니다.");
-    }
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/Team.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/Team.java
@@ -1,0 +1,7 @@
+package sopt.makers.authentication.domain.auth;
+
+public enum Team {
+  MAKERS,
+  MEDIA,
+  OPERATION;
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -1,0 +1,57 @@
+package sopt.makers.authentication.domain.auth;
+
+import lombok.*;
+
+public class User {
+
+  private final long id;
+  private final Profile profile;
+  private final SocialAccount socialAccount;
+  private ActivityList activities;
+
+  @Builder
+  public User(
+      long id,
+      final SocialAccount socialAccount,
+      final Profile profile,
+      final ActivityList activities) {
+    this.id = id;
+    this.socialAccount = socialAccount;
+    this.profile = profile;
+    this.activities = activities;
+  }
+
+  public static User createNewUser(
+      long id, final SocialAccount socialAccount, final Profile profile) {
+    return User.builder()
+        .id(id)
+        .socialAccount(socialAccount)
+        .profile(profile)
+        .activities(new ActivityList())
+        .build();
+  }
+
+  public Profile getProfile() {
+    return profile;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public SocialAccount getSocialAccount() {
+    return socialAccount;
+  }
+
+  public User updateSocialAccount(final SocialAccount socialAccount) {
+    return new User(this.id, socialAccount, this.profile, this.activities);
+  }
+
+  public ActivityList getActivityHistory() {
+    return activities;
+  }
+
+  public void join(final Activity activity) {
+    this.activities = activities.addActivity(activity);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -40,7 +40,7 @@ public class User {
     return activities;
   }
 
-  public void join(final Activity activity) {
+  public void joinActivity(final Activity activity) {
     this.activities = activities.addActivity(activity);
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -1,7 +1,8 @@
 package sopt.makers.authentication.domain.auth;
 
-import lombok.Builder;
+import lombok.*;
 
+@Getter
 public class User {
 
   private final long id;
@@ -29,18 +30,6 @@ public class User {
         .profile(profile)
         .activities(new ActivityList())
         .build();
-  }
-
-  public Profile getProfile() {
-    return profile;
-  }
-
-  public long getId() {
-    return id;
-  }
-
-  public SocialAccount getSocialAccount() {
-    return socialAccount;
   }
 
   public User updateSocialAccount(final SocialAccount socialAccount) {

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -1,6 +1,9 @@
 package sopt.makers.authentication.domain.auth;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -7,9 +7,8 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public class User {
-
   private final long id;
   private final Profile profile;
   private final SocialAccount socialAccount;
@@ -26,7 +25,12 @@ public class User {
   }
 
   public User updateSocialAccount(final SocialAccount socialAccount) {
-    return new User(this.id, this.profile, socialAccount, this.activities);
+    return User.builder()
+        .id(this.id)
+        .socialAccount(socialAccount)
+        .profile(this.profile)
+        .activities(this.activities)
+        .build();
   }
 
   public void joinActivity(final Activity activity) {

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -9,13 +9,13 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 public class User {
-  private final long id;
+  private final Long id;
   private final Profile profile;
   private final SocialAccount socialAccount;
   private ActivityList activities;
 
   public static User createNewUser(
-      long id, final SocialAccount socialAccount, final Profile profile) {
+      Long id, final SocialAccount socialAccount, final Profile profile) {
     return User.builder()
         .id(id)
         .socialAccount(socialAccount)

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -1,6 +1,6 @@
 package sopt.makers.authentication.domain.auth;
 
-import lombok.*;
+import lombok.Builder;
 
 public class User {
 

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -26,10 +26,6 @@ public class User {
     return new User(this.id, this.profile, socialAccount, this.activities);
   }
 
-  public ActivityList getActivityHistory() {
-    return activities;
-  }
-
   public void joinActivity(final Activity activity) {
     this.activities = activities.addActivity(activity);
   }

--- a/src/main/java/sopt/makers/authentication/domain/auth/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/User.java
@@ -3,24 +3,14 @@ package sopt.makers.authentication.domain.auth;
 import lombok.*;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class User {
 
   private final long id;
   private final Profile profile;
   private final SocialAccount socialAccount;
   private ActivityList activities;
-
-  @Builder
-  public User(
-      long id,
-      final SocialAccount socialAccount,
-      final Profile profile,
-      final ActivityList activities) {
-    this.id = id;
-    this.socialAccount = socialAccount;
-    this.profile = profile;
-    this.activities = activities;
-  }
 
   public static User createNewUser(
       long id, final SocialAccount socialAccount, final Profile profile) {
@@ -33,7 +23,7 @@ public class User {
   }
 
   public User updateSocialAccount(final SocialAccount socialAccount) {
-    return new User(this.id, socialAccount, this.profile, this.activities);
+    return new User(this.id, this.profile, socialAccount, this.activities);
   }
 
   public ActivityList getActivityHistory() {

--- a/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
@@ -11,7 +11,8 @@ import lombok.*;
 public enum DomainFailure implements FailureCode {
   NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다"),
   NOT_FOUND_PART(HttpStatus.NOT_FOUND, "존재하지 않는 파트입니다"),
-  INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다");
+  INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다"),
+  DUPLICATE_ACTIVITY(HttpStatus.BAD_REQUEST, "이미 존재하는 활동 정보입니다");
   private final HttpStatus status;
   private final String message;
 }

--- a/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum DomainFailure implements FailureCode {
-  ;
+  NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다");
   private final HttpStatus status;
   private final String message;
 }

--- a/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
@@ -9,7 +9,8 @@ import lombok.*;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum DomainFailure implements FailureCode {
-  NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다");
+  NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다"),
+  NOT_FOUND_PART(HttpStatus.NOT_FOUND, "존재하지 않는 파트입니다");
   private final HttpStatus status;
   private final String message;
 }

--- a/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
@@ -10,7 +10,8 @@ import lombok.*;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum DomainFailure implements FailureCode {
   NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다"),
-  NOT_FOUND_PART(HttpStatus.NOT_FOUND, "존재하지 않는 파트입니다");
+  NOT_FOUND_PART(HttpStatus.NOT_FOUND, "존재하지 않는 파트입니다"),
+  INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다");
   private final HttpStatus status;
   private final String message;
 }

--- a/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
@@ -1,0 +1,15 @@
+package sopt.makers.authentication.support.common.code.failure;
+
+import sopt.makers.authentication.support.common.code.base.*;
+
+import org.springframework.http.*;
+
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum DomainFailure implements FailureCode {
+  ;
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/common/code/failure/DomainFailure.java
@@ -12,7 +12,9 @@ public enum DomainFailure implements FailureCode {
   NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다"),
   NOT_FOUND_PART(HttpStatus.NOT_FOUND, "존재하지 않는 파트입니다"),
   INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다"),
-  DUPLICATE_ACTIVITY(HttpStatus.BAD_REQUEST, "이미 존재하는 활동 정보입니다");
+  DUPLICATE_ACTIVITY(HttpStatus.BAD_REQUEST, "이미 존재하는 활동 정보입니다"),
+  ROLE_REQUIRES_PART(HttpStatus.BAD_REQUEST, "해당 Role은 Part가 필수입니다");
+
   private final HttpStatus status;
   private final String message;
 }

--- a/src/main/java/sopt/makers/authentication/support/common/exception/DomainException.java
+++ b/src/main/java/sopt/makers/authentication/support/common/exception/DomainException.java
@@ -1,10 +1,10 @@
 package sopt.makers.authentication.support.common.exception;
 
-import sopt.makers.authentication.support.common.code.failure.*;
-import sopt.makers.authentication.support.common.exception.base.*;
+import sopt.makers.authentication.support.common.code.failure.DomainFailure;
+import sopt.makers.authentication.support.common.exception.base.BaseException;
 
 public class DomainException extends BaseException {
-  public DomainException(final AuthFailure failure) {
+  public DomainException(final DomainFailure failure) {
     super(failure);
   }
 }

--- a/src/main/java/sopt/makers/authentication/support/common/exception/DomainException.java
+++ b/src/main/java/sopt/makers/authentication/support/common/exception/DomainException.java
@@ -1,0 +1,10 @@
+package sopt.makers.authentication.support.common.exception;
+
+import sopt.makers.authentication.support.common.code.failure.*;
+import sopt.makers.authentication.support.common.exception.base.*;
+
+public class DomainException extends BaseException {
+  public DomainException(final AuthFailure failure) {
+    super(failure);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/support/config/JpaConfig.java
+++ b/src/main/java/sopt/makers/authentication/support/config/JpaConfig.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
-@EntityScan(basePackages = {"sopt.makers.authentication.database.entity"})
+@EntityScan(basePackages = {"sopt.makers.authentication.database.core.entity"})
 @EnableJpaAuditing
-@EnableJpaRepositories(basePackages = {"sopt.makers.authentication.database.repository"})
+@EnableJpaRepositories(basePackages = {"sopt.makers.authentication.database.core.repository"})
 public class JpaConfig {}

--- a/src/main/resources/jpa.yaml
+++ b/src/main/resources/jpa.yaml
@@ -11,6 +11,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
 
 ---
 spring.config.activate.on-profile: test


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #5

## Work Description ✏️
- 이전 프로젝트에서 도메인에 있던 불변 객체들을 이관해왔습니다!
- 이전에 논의한 내용을 바탕으로 공통으로 사용될 엔티티 3가지(UserActivityHistory, User, UserRegisterInfo)를 구현했습니다
![MAKERS_AUTHENTICATION](https://github.com/user-attachments/assets/c2cb0610-bb17-4602-b77c-f594c3165eba)


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- user_activity_histories와 users를 양방향으로 가져가야할 것도 같은게 toDomain 메서드를 user 엔티티에서 만들려고하니 activities를 만들어서 반환할수가 없더라고요.. 다른 분들의 의견이 궁금합니다!
- 회원가입 시점에 MemberEntity를 생성할 것으로 예상했는데, isActive 필드만 따로 파라미터로 받아도 될까요? 아니면 default는 false로 두고 업데이트를 하는게 나을까요?
- 엔티티 생성 시 builder 패턴을 쓸까요 아니면 그냥 생성자를 사용할까요? 또는 불변 객체를 사용해서 만든다는 무엇의 함수를 따로 정의하는게 나을지...
- user_register_info도 생성자가 필요할까요? 이건 회원가입 전에 저희가 db에 넣는 정보라고 생각하여 일단은 따로 만들지 않았습니다..!
- 저희 엔티티 뒤에 엔티티에는 불변 객체랑 구분하기 위해 Entity를 붙이기로했던 것 같은데 맞을까요? @yummygyudon 오빠의 이전 PR에 미리 생성한 PhoneVerification에는 붙이지 않아서 컨벤션을 맞추는게 좋을 것 같아 여쭤봅니다!