### PR TITLE
[FEAT/#18] 소셜 로그인 유즈케이스 구현

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.application.auth.api;
 
 import sopt.makers.authentication.application.auth.dto.request.AuthRequest;
+import sopt.makers.authentication.application.auth.dto.response.AuthResponse;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 
 import org.springframework.http.ResponseEntity;
@@ -12,4 +13,10 @@ public interface AuthApi {
 
   ResponseEntity<BaseResponse<?>> verifyPhoneVerification(
       AuthRequest.VerifyPhoneVerification phoneVerification);
+
+  ResponseEntity<BaseResponse<AuthResponse.AuthenticateSocialAuthInfoForWeb>>
+      authenticateSocialAuthInfoFromWeb(AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
+
+  ResponseEntity<BaseResponse<AuthResponse.AuthenticateSocialAuthInfoForApp>>
+      authenticateSocialAuthInfoFromApp(AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
@@ -1,7 +1,7 @@
 package sopt.makers.authentication.application.auth.api;
 
 import sopt.makers.authentication.application.auth.dto.request.AuthRequest;
-import sopt.makers.authentication.application.auth.dto.response.AuthResponse;
+import sopt.makers.authentication.application.auth.dto.request.AuthRequest.*;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 
 import org.springframework.http.ResponseEntity;
@@ -14,9 +14,9 @@ public interface AuthApi {
   ResponseEntity<BaseResponse<?>> verifyPhoneVerification(
       AuthRequest.VerifyPhoneVerification phoneVerification);
 
-  ResponseEntity<BaseResponse<AuthResponse.AuthenticateSocialAuthInfoForWeb>>
-      authenticateSocialAuthInfoFromWeb(AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
+  ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromWeb(
+      AuthenticateSocialAuthInfo socialAuthInfo);
 
-  ResponseEntity<BaseResponse<AuthResponse.AuthenticateSocialAuthInfoForApp>>
-      authenticateSocialAuthInfoFromApp(AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
+  ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
+      AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
@@ -1,7 +1,6 @@
 package sopt.makers.authentication.application.auth.api;
 
 import sopt.makers.authentication.application.auth.dto.request.AuthRequest;
-import sopt.makers.authentication.application.auth.dto.request.AuthRequest.*;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 
 import org.springframework.http.ResponseEntity;
@@ -15,7 +14,7 @@ public interface AuthApi {
       AuthRequest.VerifyPhoneVerification phoneVerification);
 
   ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromWeb(
-      AuthenticateSocialAuthInfo socialAuthInfo);
+      AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
 
   ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
       AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.application.auth.api;
 
 import sopt.makers.authentication.application.auth.dto.request.AuthRequest;
+import sopt.makers.authentication.application.auth.dto.response.AuthResponse;
 import sopt.makers.authentication.support.code.domain.success.AuthSuccess;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase;
@@ -32,6 +33,20 @@ public class AuthApiController implements AuthApi {
   @PostMapping("/verify/phone")
   public ResponseEntity<BaseResponse<?>> verifyPhoneVerification(
       AuthRequest.VerifyPhoneVerification phoneVerification) {
+    return null;
+  }
+
+  @Override
+  @PostMapping("/web/login")
+  public ResponseEntity<BaseResponse<AuthResponse.AuthenticateSocialAuthInfoForWeb>>
+      authenticateSocialAuthInfoFromWeb(AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
+    return null;
+  }
+
+  @Override
+  @PostMapping("/web/app")
+  public ResponseEntity<BaseResponse<AuthResponse.AuthenticateSocialAuthInfoForApp>>
+      authenticateSocialAuthInfoFromApp(AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
     return null;
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -1,11 +1,17 @@
 package sopt.makers.authentication.application.auth.api;
 
+import static sopt.makers.authentication.support.code.domain.success.AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT;
+
 import sopt.makers.authentication.application.auth.dto.request.AuthRequest;
 import sopt.makers.authentication.application.auth.dto.response.AuthResponse;
 import sopt.makers.authentication.support.code.domain.success.AuthSuccess;
 import sopt.makers.authentication.support.common.api.BaseResponse;
+import sopt.makers.authentication.support.util.CookieUtil;
+import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase;
+import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase.AuthenticateTokenInfo;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +25,8 @@ import lombok.RequiredArgsConstructor;
 public class AuthApiController implements AuthApi {
 
   private final CreatePhoneVerificationUsecase createVerificationUsecase;
+  private final AuthenticateSocialAccountUsecase authenticateSocialAccountUsecase;
+  private final CookieUtil cookieUtil;
 
   @Override
   @PostMapping("/phone")
@@ -38,15 +46,31 @@ public class AuthApiController implements AuthApi {
 
   @Override
   @PostMapping("/web/login")
-  public ResponseEntity<BaseResponse<AuthResponse.AuthenticateSocialAuthInfoForWeb>>
-      authenticateSocialAuthInfoFromWeb(AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
-    return null;
+  public ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromWeb(
+      AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
+    AuthenticateTokenInfo tokenInfo =
+        authenticateSocialAccountUsecase.authenticate(socialAuthInfo.toCommand());
+    HttpHeaders headers = cookieUtil.setRefreshToken(tokenInfo.refreshToken());
+
+    return ResponseEntity.ok()
+        .headers(headers)
+        .body(
+            BaseResponse.ofSuccess(
+                AUTHENTICATE_SOCIAL_ACCOUNT,
+                AuthResponse.AuthenticateSocialAuthInfoForWeb.of(tokenInfo.accessToken())));
   }
 
   @Override
   @PostMapping("/web/app")
-  public ResponseEntity<BaseResponse<AuthResponse.AuthenticateSocialAuthInfoForApp>>
-      authenticateSocialAuthInfoFromApp(AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
-    return null;
+  public ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
+      AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
+    AuthenticateTokenInfo tokenInfo =
+        authenticateSocialAccountUsecase.authenticate(socialAuthInfo.toCommand());
+
+    return ResponseEntity.ok(
+        BaseResponse.ofSuccess(
+            AUTHENTICATE_SOCIAL_ACCOUNT,
+            AuthResponse.AuthenticateSocialAuthInfoForApp.of(
+                tokenInfo.accessToken(), tokenInfo.refreshToken())));
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -45,7 +45,7 @@ public class AuthApiController implements AuthApi {
   }
 
   @Override
-  @PostMapping("/web/login")
+  @PostMapping("/login/web")
   public ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromWeb(
       AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
     AuthenticateTokenInfo tokenInfo =
@@ -61,7 +61,7 @@ public class AuthApiController implements AuthApi {
   }
 
   @Override
-  @PostMapping("/app/login")
+  @PostMapping("/login/app")
   public ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
       AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
     AuthenticateTokenInfo tokenInfo =

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -61,7 +61,7 @@ public class AuthApiController implements AuthApi {
   }
 
   @Override
-  @PostMapping("/web/app")
+  @PostMapping("/app/login")
   public ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
       AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo) {
     AuthenticateTokenInfo tokenInfo =

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
@@ -2,9 +2,9 @@ package sopt.makers.authentication.application.auth.dto.request;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import sopt.makers.authentication.domain.auth.*;
-import sopt.makers.authentication.usecase.auth.port.in.*;
-import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase.*;
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+import sopt.makers.authentication.domain.auth.PhoneVerificationType;
+import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase.AuthenticateSocialAccountCommand;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase.CreateVerificationCommand;
 
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public final class AuthRequest {
 
   public record VerifyPhoneVerification(String name, String number, String code) {}
 
-  public record AuthenticateSocialAccount(String code, String authPlatform) {
+  public record AuthenticateSocialAuthInfo(String code, String authPlatform) {
     public AuthenticateSocialAccountCommand toCommand() {
       return new AuthenticateSocialAccountCommand(AuthPlatform.find(authPlatform), code);
     }

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
@@ -2,7 +2,9 @@ package sopt.makers.authentication.application.auth.dto.request;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import sopt.makers.authentication.domain.auth.PhoneVerificationType;
+import sopt.makers.authentication.domain.auth.*;
+import sopt.makers.authentication.usecase.auth.port.in.*;
+import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase.*;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase.CreateVerificationCommand;
 
 import lombok.RequiredArgsConstructor;
@@ -18,4 +20,10 @@ public final class AuthRequest {
   }
 
   public record VerifyPhoneVerification(String name, String number, String code) {}
+
+  public record AuthenticateSocialAccount(String code, String authPlatform) {
+    public AuthenticateSocialAccountCommand toCommand() {
+      return new AuthenticateSocialAccountCommand(AuthPlatform.find(authPlatform), code);
+    }
+  }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
@@ -6,7 +6,15 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = PRIVATE)
 public final class AuthResponse {
-  public record AuthenticateSocialAuthInfoForWeb(String accessToken) {}
+  public record AuthenticateSocialAuthInfoForWeb(String accessToken) {
+    public static AuthenticateSocialAuthInfoForWeb of(String accessToken) {
+      return new AuthenticateSocialAuthInfoForWeb(accessToken);
+    }
+  }
 
-  public record AuthenticateSocialAuthInfoForApp(String accessToken, String refreshToken) {}
+  public record AuthenticateSocialAuthInfoForApp(String accessToken, String refreshToken) {
+    public static AuthenticateSocialAuthInfoForApp of(String accessToken, String refreshToken) {
+      return new AuthenticateSocialAuthInfoForApp(accessToken, refreshToken);
+    }
+  }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
@@ -5,4 +5,8 @@ import static lombok.AccessLevel.PRIVATE;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = PRIVATE)
-public final class AuthResponse {}
+public final class AuthResponse {
+  public record AuthenticateSocialAuthInfoForWeb(String accessToken) {}
+
+  public record AuthenticateSocialAuthInfoForApp(String accessToken, String refreshToken) {}
+}

--- a/src/main/java/sopt/makers/authentication/database/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/UserRepositoryImpl.java
@@ -1,0 +1,21 @@
+package sopt.makers.authentication.database;
+
+import sopt.makers.authentication.database.rdb.repository.UserRetriever;
+import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+  private final UserRetriever userRetriever;
+
+  @Override
+  public User findBySocialAccount(SocialAccount socialAccount) {
+    return userRetriever.findBySocialAccount(socialAccount);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/database/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/UserRepositoryImpl.java
@@ -18,4 +18,9 @@ public class UserRepositoryImpl implements UserRepository {
   public User findBySocialAccount(SocialAccount socialAccount) {
     return userRetriever.findBySocialAccount(socialAccount);
   }
+
+  @Override
+  public Long findIdByUser(User user) {
+    return userRetriever.findIdByUser(user);
+  }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/UserJpaRepository.java
@@ -5,9 +5,16 @@ import sopt.makers.authentication.domain.auth.AuthPlatform;
 
 import java.util.Optional;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.*;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
   Optional<UserEntity> findByAuthPlatformTypeAndAuthPlatformId(
       AuthPlatform authPlatformType, String authPlatformId);
+
+  @Query(
+      "SELECT u.id FROM UserEntity u WHERE u.authPlatformType = :authPlatformType AND u.authPlatformId = :authPlatformId")
+  Optional<Long> findIdByAuthPlatformTypeAndAuthPlatformId(
+      @Param("authPlatformType") AuthPlatform authPlatformType,
+      @Param("authPlatformId") String authPlatformId);
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/UserJpaRepository.java
@@ -1,0 +1,13 @@
+package sopt.makers.authentication.database.rdb.repository;
+
+import sopt.makers.authentication.database.rdb.entity.UserEntity;
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+  Optional<UserEntity> findByAuthPlatformTypeAndAuthPlatformId(
+      AuthPlatform authPlatformType, String authPlatformId);
+}

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/UserJpaRepository.java
@@ -12,9 +12,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
   Optional<UserEntity> findByAuthPlatformTypeAndAuthPlatformId(
       AuthPlatform authPlatformType, String authPlatformId);
 
-  @Query(
-      "SELECT u.id FROM UserEntity u WHERE u.authPlatformType = :authPlatformType AND u.authPlatformId = :authPlatformId")
   Optional<Long> findIdByAuthPlatformTypeAndAuthPlatformId(
-      @Param("authPlatformType") AuthPlatform authPlatformType,
-      @Param("authPlatformId") String authPlatformId);
+      AuthPlatform authPlatformType, String authPlatformId);
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/UserRetriever.java
@@ -3,7 +3,7 @@ package sopt.makers.authentication.database.rdb.repository;
 import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT;
 
 import sopt.makers.authentication.database.rdb.entity.UserEntity;
-import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.auth.*;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.support.exception.domain.AuthException;
 
@@ -25,5 +25,13 @@ public class UserRetriever {
                 socialAccount.authPlatformType(), socialAccount.authPlatformId())
             .orElseThrow(() -> new AuthException(NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT));
     return userEntity.toDomain();
+  }
+
+  public Long findIdByUser(User user) {
+    AuthPlatform authPlatformType = user.getSocialAccount().authPlatformType();
+    String authPlatformId = user.getSocialAccount().authPlatformId();
+    return userJpaRepository
+        .findIdByAuthPlatformTypeAndAuthPlatformId(authPlatformType, authPlatformId)
+        .orElseThrow(() -> new AuthException(NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT));
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/UserRetriever.java
@@ -1,0 +1,29 @@
+package sopt.makers.authentication.database.rdb.repository;
+
+import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT;
+
+import sopt.makers.authentication.database.rdb.entity.UserEntity;
+import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.support.exception.domain.AuthException;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserRetriever {
+  private final UserJpaRepository userJpaRepository;
+
+  public User findBySocialAccount(SocialAccount socialAccount) {
+    UserEntity userEntity =
+        userJpaRepository
+            .findByAuthPlatformTypeAndAuthPlatformId(
+                socialAccount.authPlatformType(), socialAccount.authPlatformId())
+            .orElseThrow(() -> new AuthException(NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT));
+    return userEntity.toDomain();
+  }
+}

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum AuthFailure implements FailureCode {
   INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다"),
-  ;
+  NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 계정 정보와 일치하는 회원이 없습니다");
   private final HttpStatus status;
   private final String message;
 }

--- a/src/main/java/sopt/makers/authentication/support/code/domain/success/AuthSuccess.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/success/AuthSuccess.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum AuthSuccess implements SuccessCode {
   CREATE_PHONE_VERIFICATION(HttpStatus.CREATED, "번호 인증 생성에 성공했습니다."),
-  ;
+  AUTHENTICATE_SOCIAL_ACCOUNT(HttpStatus.OK, "소셜 로그인에 성공했습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/sopt/makers/authentication/support/constant/JwtConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/JwtConstant.java
@@ -3,4 +3,5 @@ package sopt.makers.authentication.support.constant;
 public class JwtConstant {
 
   public static final String TOKEN_HEADER = "Bearer ";
+  public static final String REFRESH_TOKEN_HEADER = "refresh-token";
 }

--- a/src/main/java/sopt/makers/authentication/support/constant/OAuthConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/OAuthConstant.java
@@ -1,6 +1,11 @@
 package sopt.makers.authentication.support.constant;
 
-public abstract class OAuthConstant {
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.*;
+
+@RequiredArgsConstructor(access = PRIVATE)
+public final class OAuthConstant {
   public static final String CLIENT_ID = "client_id";
   public static final String CLIENT_SECRET = "client_secret";
   public static final String CODE = "code";

--- a/src/main/java/sopt/makers/authentication/support/constant/OAuthConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/OAuthConstant.java
@@ -2,7 +2,7 @@ package sopt.makers.authentication.support.constant;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import lombok.*;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = PRIVATE)
 public final class OAuthConstant {

--- a/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
@@ -13,4 +13,5 @@ public final class SystemConstant {
   public static final String PATTERN_ERROR_PATH = "/error";
   public static final String PATTERN_AUTH = API_DEFAULT_PREFIX + "/auth" + PATTERN_ALL;
   public static final String PATTERN_TEST = API_DEFAULT_PREFIX + "/test" + PATTERN_ALL;
+  public static final String PATTERN_ROOT_PATH = "/";
 }

--- a/src/main/java/sopt/makers/authentication/support/util/CookieUtil.java
+++ b/src/main/java/sopt/makers/authentication/support/util/CookieUtil.java
@@ -1,0 +1,38 @@
+package sopt.makers.authentication.support.util;
+
+import static sopt.makers.authentication.support.constant.JwtConstant.REFRESH_TOKEN_HEADER;
+import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_ROOT_PATH;
+
+import sopt.makers.authentication.support.value.JwtProperty;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class CookieUtil {
+  private final JwtProperty jwtProperty;
+  private static final String SAME_SITE_NONE = "None";
+
+  public HttpHeaders setRefreshToken(String refreshToken) {
+    long durationMillis = jwtProperty.secret().expiration().refreshTokenExpiration();
+    Duration duration = Duration.ofMillis(durationMillis);
+    ResponseCookie cookie =
+        ResponseCookie.from(REFRESH_TOKEN_HEADER, refreshToken)
+            .httpOnly(true)
+            .secure(true)
+            .sameSite(SAME_SITE_NONE)
+            .path(PATTERN_ROOT_PATH)
+            .maxAge(duration)
+            .build();
+    HttpHeaders headers = new HttpHeaders();
+
+    headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
+    return headers;
+  }
+}

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/in/AuthenticateSocialAccountUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/in/AuthenticateSocialAccountUsecase.java
@@ -3,11 +3,11 @@ package sopt.makers.authentication.usecase.auth.port.in;
 import sopt.makers.authentication.domain.auth.AuthPlatform;
 
 public interface AuthenticateSocialAccountUsecase {
-  SocialAccountInfo authenticate(AuthenticateSocialAccountCommand command);
+  AuthenticateTokenInfo authenticate(AuthenticateSocialAccountCommand command);
 
-  record SocialAccountInfo(String authPlatformId, String authPlatformType) {
-    public static SocialAccountInfo of(String authPlatformId, String authPlatformType) {
-      return new SocialAccountInfo(authPlatformId, authPlatformType);
+  record AuthenticateTokenInfo(String accessToken, String refreshToken) {
+    public static AuthenticateTokenInfo of(String accessToken, String refreshToken) {
+      return new AuthenticateTokenInfo(accessToken, refreshToken);
     }
   }
 

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
@@ -1,0 +1,8 @@
+package sopt.makers.authentication.usecase.auth.port.out;
+
+import sopt.makers.authentication.domain.auth.*;
+import sopt.makers.authentication.domain.user.*;
+
+public interface UserRepository {
+  User findBySocialAccount(SocialAccount socialAccount);
+}

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
@@ -5,4 +5,6 @@ import sopt.makers.authentication.domain.user.User;
 
 public interface UserRepository {
   User findBySocialAccount(SocialAccount socialAccount);
+
+  Long findIdByUser(User user);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
@@ -1,7 +1,7 @@
 package sopt.makers.authentication.usecase.auth.port.out;
 
-import sopt.makers.authentication.domain.auth.*;
-import sopt.makers.authentication.domain.user.*;
+import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.User;
 
 public interface UserRepository {
   User findBySocialAccount(SocialAccount socialAccount);

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -1,7 +1,16 @@
 package sopt.makers.authentication.usecase.auth.service;
 
+import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Role;
+import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.support.jwt.provider.JwtAuthAccessTokenProvider;
+import sopt.makers.authentication.support.jwt.provider.JwtAuthRefreshTokenProvider;
+import sopt.makers.authentication.support.security.authentication.CustomAuthentication;
 import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
+import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
+
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
@@ -11,12 +20,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthenticateSocialAccountService implements AuthenticateSocialAccountUsecase {
   private final OAuthAuthenticator oAuthAuthenticator;
+  private final UserRepository userRepository;
+  private final JwtAuthAccessTokenProvider jwtAuthAccessTokenProvider;
+  private final JwtAuthRefreshTokenProvider jwtAuthRefreshTokenProvider;
 
   @Override
-  public SocialAccountInfo authenticate(AuthenticateSocialAccountCommand command) {
+  public AuthenticateTokenInfo authenticate(AuthenticateSocialAccountCommand command) {
     String authPlatformId =
         oAuthAuthenticator.getAuthPlatformId(command.authPlatform(), command.code());
-
-    return SocialAccountInfo.of(authPlatformId, command.authPlatform().name());
+    User user =
+        userRepository.findBySocialAccount(
+            SocialAccount.of(authPlatformId, command.authPlatform().name()));
+    List<Role> roles = List.of(user.getActivities().getLastActivity().role());
+    CustomAuthentication customAuthentication =
+        new CustomAuthentication(user, roles); // TODO: subject 수정
+    String accessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
+    String refreshToken = jwtAuthRefreshTokenProvider.generate(accessToken);
+    return AuthenticateTokenInfo.of(accessToken, refreshToken);
   }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -32,10 +32,11 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
         userRepository.findBySocialAccount(
             SocialAccount.of(authPlatformId, command.authPlatform().name()));
     List<Role> roles = List.of(user.getActivities().getLastActivity().role());
-    CustomAuthentication customAuthentication =
-        new CustomAuthentication(user, roles); // TODO: subject 수정
+    Long userId = userRepository.findIdByUser(user);
+    CustomAuthentication customAuthentication = new CustomAuthentication(userId, roles);
     String accessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
     String refreshToken = jwtAuthRefreshTokenProvider.generate(accessToken);
+
     return AuthenticateTokenInfo.of(accessToken, refreshToken);
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #18

## Work Description ✏️
- 소셜 로그인 유즈케이스를 작성했습니다
1. `usercase`: 유저로부터 role & id 값을 찾아와 CustomAuthentication을 생성했습니다
- id 이외에 user를 식별할 수 있는 값이 소셜 플랫폼 & 소셜 플랫폼 id 조합이라고 생각했습니다
- 이런 방식을 사용해 id를 가져오는 것이 괜찮으신지 궁금합니다
2. `application`: web, app 경로를 나누었고 resonse도 구분하여 작성해두었습니다
- 토큰을 생성하여 header에 담기 위해 CookieUtil 클래스를 추가했습니다
3. 컨트롤러 코드를 작성하며 `return ResponseEntity~~`에 대한 코드가 중복된다고 생각했습니다.
- 이에 대해 ApiUtil 객체를 통해 BaseResposne를 받아 ApiUtil 내에서 success, fail를 구현하여 반환시키는 것은 어떠신지 궁금합니다
- ex)
```
public <T> ResponseEntity<BaseResponse<T>> success(SuccessCode code, T data) {
        return ResponseEntity
                .status(code.getStatus())
                .body(BaseResponse.of(code.getMessage(), data));
    }
```


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- userId 조회 방식이 적절한지 궁금합니다
- 3번 제안에 대한 생각이 궁금합니다!
- 테스트코드는 userId 조회 로직에 대한 리뷰를 1차적으로 받고싶어 작성 전에 PR을 날리게 되었습니다! 너무 바쁘시다면 이 부분에 대해서만 1차적으로 의견 남겨주시고 테스트코드 작성 commit 반영 이후에 전반적으로 리뷰를 남겨주셔도 좋을 것 같아요 ㅎ