### PR TITLE
[FEAT/#16] 회원가입 API 구현

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
@@ -19,5 +19,5 @@ public interface AuthApi {
   ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
       AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
 
-  ResponseEntity<BaseResponse<?>> signUp(AuthRequest.SignUp signUp);
+  ResponseEntity<BaseResponse<?>> signUp(AuthRequest.SignUpInfo signUp);
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
@@ -18,4 +18,6 @@ public interface AuthApi {
 
   ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
       AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
+
+  ResponseEntity<BaseResponse<?>> signUp(AuthRequest.SignUp signUp);
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -79,8 +79,8 @@ public class AuthApiController implements AuthApi {
 
   @Override
   @PostMapping("/signup")
-  public ResponseEntity<BaseResponse<?>> signUp(AuthRequest.SignUp signUp) {
-    signUpUsecase.signUp(signUp.toCommand());
+  public ResponseEntity<BaseResponse<?>> signUp(AuthRequest.SignUpInfo signUpInfo) {
+    signUpUsecase.signUp(signUpInfo.toCommand());
     return ResponseUtil.success(AuthSuccess.CREATE_SIGN_UP_USER);
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -9,6 +9,7 @@ import sopt.makers.authentication.support.util.ResponseUtil;
 import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase;
 import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase.AuthenticateTokenInfo;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase;
+import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase;
 import sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase;
 
 import org.springframework.http.HttpHeaders;
@@ -28,6 +29,7 @@ public class AuthApiController implements AuthApi {
   private final CreatePhoneVerificationUsecase createVerificationUsecase;
   private final VerifyPhoneVerificationUsecase verifyVerificationUsecase;
   private final AuthenticateSocialAccountUsecase authenticateSocialAccountUsecase;
+  private final SignUpUsecase signUpUsecase;
   private final CookieUtil cookieUtil;
 
   @Override
@@ -73,5 +75,12 @@ public class AuthApiController implements AuthApi {
         AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
         AuthResponse.AuthenticateSocialAuthInfoForApp.of(
             tokenInfo.accessToken(), tokenInfo.refreshToken()));
+  }
+
+  @Override
+  @PostMapping("/signup")
+  public ResponseEntity<BaseResponse<?>> signUp(AuthRequest.SignUp signUp) {
+    signUpUsecase.signUp(signUp.toCommand());
+    return ResponseUtil.success(AuthSuccess.CREATE_SIGN_UP_USER);
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
@@ -46,14 +46,14 @@ public final class AuthRequest {
     }
   }
 
-  public record SignUp(
+  public record SignUpInfo(
       @JsonProperty("name") String name,
       @JsonProperty("phone") String phone,
-      @JsonProperty("code") String code,
+      @JsonProperty("token") String token,
       @JsonProperty("authPlatform") String authPlatform) {
     public SignUpCommand toCommand() {
       return new SignUpCommand(
-          this.name, this.phone, this.code, AuthPlatform.find(this.authPlatform));
+          this.name, this.phone, this.token, AuthPlatform.find(this.authPlatform));
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
@@ -2,9 +2,11 @@ package sopt.makers.authentication.application.auth.dto.request;
 
 import static lombok.AccessLevel.PRIVATE;
 
+import sopt.makers.authentication.domain.auth.AuthPlatform;
 import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase.AuthenticateSocialAccountCommand;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase.CreateVerificationCommand;
+import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase.SignUpCommand;
 import sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase.VerifyVerificationCommand;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -41,6 +43,17 @@ public final class AuthRequest {
   public record AuthenticateSocialAuthInfo(String code, String authPlatform) {
     public AuthenticateSocialAccountCommand toCommand() {
       return AuthenticateSocialAccountCommand.of(authPlatform, code);
+    }
+  }
+
+  public record SignUp(
+      @JsonProperty("name") String name,
+      @JsonProperty("phone") String phone,
+      @JsonProperty("code") String code,
+      @JsonProperty("authPlatform") String authPlatform) {
+    public SignUpCommand toCommand() {
+      return new SignUpCommand(
+          this.name, this.phone, this.code, AuthPlatform.find(this.authPlatform));
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/UserRegisterInfoRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/UserRegisterInfoRepositoryImpl.java
@@ -22,4 +22,10 @@ public class UserRegisterInfoRepositoryImpl implements UserRegisterInfoRepositor
     UserRegisterInfoEntity targetRegisterInfo = retriever.findByPhone(phone);
     return targetRegisterInfo.toDomain();
   }
+
+  @Override
+  public void delete(UserRegisterInfo userRegisterInfo) {
+    UserRegisterInfoEntity registerInfoEntity = retriever.findByPhone(userRegisterInfo.getPhone());
+    remover.remove(registerInfoEntity);
+  }
 }

--- a/src/main/java/sopt/makers/authentication/database/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/UserRepositoryImpl.java
@@ -28,6 +28,12 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
+  public void save(User user) {
+    UserEntity userEntity = UserEntity.fromDomain(user);
+    userRegister.save(userEntity);
+  }
+
+  @Override
   public User findByPhone(String phone) {
     return userRetriever.findByPhone(phone);
   }

--- a/src/main/java/sopt/makers/authentication/database/rdb/entity/UserRegisterInfoEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/entity/UserRegisterInfoEntity.java
@@ -29,6 +29,7 @@ public class UserRegisterInfoEntity {
 
   @NotNull private String name;
   @NotNull private String phone;
+  @NotNull private String email;
   @NotNull private LocalDate birthday;
 
   @Min(1)
@@ -39,6 +40,7 @@ public class UserRegisterInfoEntity {
   private Part part;
 
   public UserRegisterInfo toDomain() {
-    return UserRegisterInfo.of(this.name, this.phone, this.birthday, this.generation, this.part);
+    return UserRegisterInfo.of(
+        this.name, this.phone, this.email, this.birthday, this.generation, this.part);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/UserRegisterInfoRemover.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/UserRegisterInfoRemover.java
@@ -1,8 +1,20 @@
 package sopt.makers.authentication.database.rdb.repository;
 
+import sopt.makers.authentication.database.rdb.entity.UserRegisterInfoEntity;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
 @Transactional
-public class UserRegisterInfoRemover {}
+@RequiredArgsConstructor
+public class UserRegisterInfoRemover {
+  private final UserRegisterInfoJpaRepository jpaRepository;
+
+  public void remove(final UserRegisterInfoEntity entity) {
+
+    jpaRepository.delete(entity);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/user/UserRegisterInfo.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/UserRegisterInfo.java
@@ -14,12 +14,13 @@ import lombok.RequiredArgsConstructor;
 public class UserRegisterInfo {
   private final String name;
   private final String phone;
+  private final String email;
   private final LocalDate birthday;
   private final int generation;
   private final Part part;
 
   public static UserRegisterInfo of(
-      String name, String phone, LocalDate birthday, int generation, Part part) {
-    return new UserRegisterInfo(name, phone, birthday, generation, part);
+      String name, String phone, String email, LocalDate birthday, int generation, Part part) {
+    return new UserRegisterInfo(name, phone, email, birthday, generation, part);
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
@@ -1,75 +1,95 @@
 package sopt.makers.authentication.external.oauth;
 
-import static sopt.makers.authentication.support.code.external.failure.ClientError.APPLE_RESPONSE_UNAVAILABLE;
-import static sopt.makers.authentication.support.code.external.failure.ClientError.FAIL_READ_APPLE_PRIVATE_KEY_FILE;
-import static sopt.makers.authentication.support.code.external.failure.ClientError.INVALID_APPLE_AUTH_CODE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.ACCEPT;
-import static sopt.makers.authentication.support.constant.OAuthConstant.ACCEPT_VALUE;
+import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
 import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_ALGORITHM_HEADER;
 import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_ALGORITHM_VALUE;
+import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_ISSUER;
 import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_KEY_ID_HEADER;
-import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_TOKEN_URL;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CLIENT_ID;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CLIENT_SECRET;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CODE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CONTENT_TYPE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CONTENT_TYPE_VALUE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.GRANT_TYPE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.GRANT_TYPE_VALUE;
 
+import sopt.makers.authentication.external.oauth.client.AppleAuthClient;
 import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
+import sopt.makers.authentication.support.code.domain.failure.AuthFailure;
+import sopt.makers.authentication.support.code.support.failure.TokenFailure;
+import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.support.exception.external.ClientRequestException;
-import sopt.makers.authentication.support.exception.external.ClientResponseException;
+import sopt.makers.authentication.support.exception.support.TokenException;
 import sopt.makers.authentication.support.util.*;
 import sopt.makers.authentication.support.value.AppleOAuthProperty;
 
-import java.io.IOException;
 import java.security.PrivateKey;
+import java.text.ParseException;
+import java.time.Instant;
 import java.util.Date;
 
 import org.springframework.stereotype.Component;
 
-import com.google.gson.Gson;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.FormBody;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class AppleAuthService implements OAuthService {
   private final AppleOAuthProperty appleOAuthProperty;
-  private final Gson gson;
-  private final OkHttpClient client;
+  private final AppleAuthClient appleAuthClient;
 
   @Override
   public IdTokenResponse getIdTokenByCode(final String code) {
-    FormBody formBody = createTokenRequestFormBody(code);
-    Request request = createHttpRequest(formBody);
-    Response response = executeRequest(request);
-
-    return parseResponseBody(response);
-  }
-
-  private FormBody createTokenRequestFormBody(final String code) {
-    String clientId = appleOAuthProperty.sub();
     String clientSecret = createClientSecret();
-    return new FormBody.Builder()
-        .add(CLIENT_ID, clientId)
-        .add(CLIENT_SECRET, clientSecret)
-        .add(CODE, code)
-        .add(GRANT_TYPE, GRANT_TYPE_VALUE)
-        .build();
+    return appleAuthClient.getIdToken(clientSecret, code);
   }
 
+  public String getIdentifierByToken(final String token) {
+    try {
+      SignedJWT signedJWT = SignedJWT.parse(token);
+      JWK targetJwk = findMatchJWK(signedJWT);
+
+      verifyAppleIdTokenJwt(signedJWT, targetJwk);
+      String identifier = signedJWT.getJWTClaimsSet().getSubject();
+      return identifier;
+    } catch (ParseException e) {
+      throw new TokenException(TokenFailure.TOKEN_PARSE_FAILED);
+    }
+  }
+
+  private JWK findMatchJWK(final SignedJWT jwt) {
+    JWKSet loadedJWKSet = appleAuthClient.getPublicKeySet();
+    String keyID = jwt.getHeader().getKeyID();
+    return loadedJWKSet.getKeys().stream()
+        .filter(jwk -> jwk.getKeyID().equals(keyID))
+        .findFirst()
+        .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET));
+  }
+
+  private void verifyAppleIdTokenJwt(final SignedJWT jwt, JWK jwk) throws ParseException {
+    try {
+      JWTClaimsSet jwtClaimsSet = jwt.getJWTClaimsSet();
+      JWSVerifier verifier = new ECDSAVerifier(jwk.toECKey());
+
+      boolean isVerifiedSignature = jwt.verify(verifier);
+      boolean isCorrectIssuer = jwtClaimsSet.getIssuer().equals(APPLE_ISSUER);
+      boolean isCorrectAudience = jwtClaimsSet.getAudience().contains(appleOAuthProperty.aud());
+      boolean isNotExpired = jwtClaimsSet.getExpirationTime().after(Date.from(Instant.now()));
+
+      if (!(isVerifiedSignature && isCorrectIssuer && isCorrectAudience && isNotExpired)) {
+        throw new AuthException(AuthFailure.INVALID_ID_TOKEN);
+      }
+    } catch (JOSEException e) {
+      throw new AuthException(AuthFailure.INVALID_ID_TOKEN);
+    }
+  }
+
+  // TODO : AuthXXX 객체에서 ClientXXXException 발생하는 구조는 개선되면 좋을 것 같습니다. (@동규)
   private String createClientSecret() {
     Date now = new Date();
     PrivateKey privateKey =
@@ -86,43 +106,5 @@ public class AppleAuthService implements OAuthService {
         .setSubject(appleOAuthProperty.sub())
         .signWith(privateKey, SignatureAlgorithm.ES256)
         .compact();
-  }
-
-  private static Request createHttpRequest(RequestBody requestBody) {
-    return new Request.Builder()
-        .url(APPLE_TOKEN_URL)
-        .post(requestBody)
-        .addHeader(CONTENT_TYPE, CONTENT_TYPE_VALUE)
-        .addHeader(ACCEPT, ACCEPT_VALUE)
-        .build();
-  }
-
-  private Response executeRequest(Request request) {
-    try {
-      Response response = client.newCall(request).execute();
-
-      validateResponse(response);
-      return response;
-    } catch (IOException e) {
-      throw new ClientResponseException(APPLE_RESPONSE_UNAVAILABLE);
-    }
-  }
-
-  private void validateResponse(Response response) {
-    boolean isNotSuccessResponse = !response.isSuccessful();
-
-    if (isNotSuccessResponse) {
-      throw new ClientRequestException(INVALID_APPLE_AUTH_CODE);
-    }
-  }
-
-  private IdTokenResponse parseResponseBody(Response response) {
-    ResponseBody responseBody = response.body();
-    boolean isBodyNull = responseBody == null;
-
-    if (isBodyNull) {
-      throw new ClientResponseException(APPLE_RESPONSE_UNAVAILABLE);
-    }
-    return gson.fromJson(response.body().toString(), IdTokenResponse.class);
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
@@ -1,98 +1,85 @@
 package sopt.makers.authentication.external.oauth;
 
-import static sopt.makers.authentication.support.code.external.failure.ClientError.GOOGLE_RESPONSE_UNAVAILABLE;
-import static sopt.makers.authentication.support.code.external.failure.ClientError.INVALID_GOOGLE_AUTH_CODE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.ACCEPT;
-import static sopt.makers.authentication.support.constant.OAuthConstant.ACCEPT_VALUE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CLIENT_ID;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CLIENT_SECRET;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CODE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CONTENT_TYPE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.CONTENT_TYPE_VALUE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.GOOGLE_TOKEN_URL;
-import static sopt.makers.authentication.support.constant.OAuthConstant.GRANT_TYPE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.GRANT_TYPE_VALUE;
-import static sopt.makers.authentication.support.constant.OAuthConstant.REDIRECT_URI;
+import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
+import static sopt.makers.authentication.support.constant.OAuthConstant.*;
 
+import sopt.makers.authentication.external.oauth.client.GoogleAuthClient;
 import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
-import sopt.makers.authentication.support.exception.external.ClientRequestException;
-import sopt.makers.authentication.support.exception.external.ClientResponseException;
+import sopt.makers.authentication.support.code.domain.failure.AuthFailure;
+import sopt.makers.authentication.support.code.support.failure.TokenFailure;
+import sopt.makers.authentication.support.exception.domain.AuthException;
+import sopt.makers.authentication.support.exception.support.TokenException;
 import sopt.makers.authentication.support.value.GoogleOAuthProperty;
 
-import java.io.IOException;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
 
 import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 
 import lombok.RequiredArgsConstructor;
-import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 @Component
 @RequiredArgsConstructor
 public class GoogleAuthService implements OAuthService {
   private final GoogleOAuthProperty googleOAuthProperty;
+  private final GoogleAuthClient googleAuthClient;
   private final Gson gson;
   private final OkHttpClient client;
 
   @Override
   public IdTokenResponse getIdTokenByCode(String code) {
-    FormBody formBody = createTokenRequestFormBody(code);
-    Request request = createHttpRequest(formBody);
-    Response response = executeRequest(request);
-
-    return parseResponseBody(response);
+    return googleAuthClient.getIdToken(googleOAuthProperty.client().secret(), code);
   }
 
-  private FormBody createTokenRequestFormBody(String code) {
-    return new FormBody.Builder()
-        .add(CLIENT_ID, googleOAuthProperty.client().id())
-        .add(CLIENT_SECRET, googleOAuthProperty.client().secret())
-        .add(CODE, code)
-        .add(GRANT_TYPE, GRANT_TYPE_VALUE)
-        .add(REDIRECT_URI, googleOAuthProperty.redirect().url())
-        .build();
-  }
-
-  private static Request createHttpRequest(FormBody formBody) {
-    return new Request.Builder()
-        .url(GOOGLE_TOKEN_URL)
-        .post(formBody)
-        .addHeader(CONTENT_TYPE, CONTENT_TYPE_VALUE)
-        .addHeader(ACCEPT, ACCEPT_VALUE)
-        .build();
-  }
-
-  private Response executeRequest(Request request) {
+  public String getIdentifierByToken(final String token) {
     try {
-      Response response = client.newCall(request).execute();
+      SignedJWT signedJWT = SignedJWT.parse(token);
+      JWK targetJwk = findMatchJWK(signedJWT);
 
-      validateResponse(response);
-      return response;
-    } catch (IOException e) {
-      throw new ClientResponseException(GOOGLE_RESPONSE_UNAVAILABLE);
+      verifyAppleIdTokenJwt(signedJWT, targetJwk);
+      String identifier = signedJWT.getJWTClaimsSet().getSubject();
+      return identifier;
+    } catch (ParseException e) {
+      throw new TokenException(TokenFailure.TOKEN_PARSE_FAILED);
     }
   }
 
-  private void validateResponse(Response response) {
-    boolean isNotSuccessResponse = !response.isSuccessful();
-
-    if (isNotSuccessResponse) {
-      throw new ClientRequestException(INVALID_GOOGLE_AUTH_CODE);
-    }
+  private JWK findMatchJWK(final SignedJWT jwt) {
+    JWKSet loadedJWKSet = googleAuthClient.getPublicKeySet();
+    String keyID = jwt.getHeader().getKeyID();
+    return loadedJWKSet.getKeys().stream()
+        .filter(jwk -> jwk.getKeyID().equals(keyID))
+        .findFirst()
+        .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET));
   }
 
-  private IdTokenResponse parseResponseBody(Response response) {
-    ResponseBody responseBody = response.body();
-    boolean isBodyNull = responseBody == null;
+  private void verifyAppleIdTokenJwt(final SignedJWT jwt, JWK jwk) throws ParseException {
+    try {
+      JWTClaimsSet jwtClaimsSet = jwt.getJWTClaimsSet();
+      JWSVerifier verifier = new ECDSAVerifier(jwk.toECKey());
 
-    if (isBodyNull) {
-      throw new ClientResponseException(GOOGLE_RESPONSE_UNAVAILABLE);
+      boolean isVerifiedSignature = jwt.verify(verifier);
+      boolean isCorrectIssuer = jwtClaimsSet.getIssuer().equals(GOOGLE_ISSUER);
+      boolean isCorrectAudience =
+          jwtClaimsSet.getAudience().contains(googleOAuthProperty.client().id());
+      boolean isNotExpired = jwtClaimsSet.getExpirationTime().after(Date.from(Instant.now()));
+
+      if (!(isVerifiedSignature && isCorrectIssuer && isCorrectAudience && isNotExpired)) {
+        throw new AuthException(AuthFailure.INVALID_ID_TOKEN);
+      }
+    } catch (JOSEException e) {
+      throw new AuthException(AuthFailure.INVALID_ID_TOKEN);
     }
-    return gson.fromJson(responseBody.toString(), IdTokenResponse.class);
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
@@ -1,6 +1,5 @@
 package sopt.makers.authentication.external.oauth;
 
-import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
 import static sopt.makers.authentication.support.constant.OAuthConstant.*;
 
 import sopt.makers.authentication.external.oauth.client.GoogleAuthClient;
@@ -17,7 +16,6 @@ import java.util.Date;
 
 import org.springframework.stereotype.Component;
 
-import com.google.gson.Gson;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
@@ -27,15 +25,12 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
 import lombok.RequiredArgsConstructor;
-import okhttp3.OkHttpClient;
 
 @Component
 @RequiredArgsConstructor
 public class GoogleAuthService implements OAuthService {
   private final GoogleOAuthProperty googleOAuthProperty;
   private final GoogleAuthClient googleAuthClient;
-  private final Gson gson;
-  private final OkHttpClient client;
 
   @Override
   public IdTokenResponse getIdTokenByCode(String code) {
@@ -47,7 +42,7 @@ public class GoogleAuthService implements OAuthService {
       SignedJWT signedJWT = SignedJWT.parse(token);
       JWK targetJwk = findMatchJWK(signedJWT);
 
-      verifyAppleIdTokenJwt(signedJWT, targetJwk);
+      verifyGoogleIdTokenJwt(signedJWT, targetJwk);
       String identifier = signedJWT.getJWTClaimsSet().getSubject();
       return identifier;
     } catch (ParseException e) {
@@ -64,7 +59,7 @@ public class GoogleAuthService implements OAuthService {
         .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET));
   }
 
-  private void verifyAppleIdTokenJwt(final SignedJWT jwt, JWK jwk) throws ParseException {
+  private void verifyGoogleIdTokenJwt(final SignedJWT jwt, JWK jwk) throws ParseException {
     try {
       JWTClaimsSet jwtClaimsSet = jwt.getJWTClaimsSet();
       JWSVerifier verifier = new ECDSAVerifier(jwk.toECKey());

--- a/src/main/java/sopt/makers/authentication/external/oauth/OAuthAuthenticatorImpl.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/OAuthAuthenticatorImpl.java
@@ -1,9 +1,10 @@
 package sopt.makers.authentication.external.oauth;
 
+import static sopt.makers.authentication.domain.auth.AuthPlatform.APPLE;
+import static sopt.makers.authentication.domain.auth.AuthPlatform.GOOGLE;
 import static sopt.makers.authentication.support.code.external.failure.ClientError.INVALID_ID_TOKEN;
 
 import sopt.makers.authentication.domain.auth.AuthPlatform;
-import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
 import sopt.makers.authentication.support.exception.external.*;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 
@@ -22,22 +23,30 @@ public class OAuthAuthenticatorImpl implements OAuthAuthenticator {
   private final AppleAuthService appleAuthService;
   private final GoogleAuthService googleAuthService;
 
+  @Override
   public String getAuthPlatformId(String authPlatform, String code) {
-    IdTokenResponse idTokenResponse = getIdTokenByCode(authPlatform, code);
-    return parseAuthPlatformId(idTokenResponse);
+    String idToken = getIdTokenByCode(authPlatform, code);
+    return parseAuthPlatformId(idToken);
   }
 
-  public IdTokenResponse getIdTokenByCode(String authPlatform, String code) {
-    AuthPlatform type = AuthPlatform.find(authPlatform);
-
-    return switch (type) {
-      case APPLE -> appleAuthService.getIdTokenByCode(code);
-      case GOOGLE -> googleAuthService.getIdTokenByCode(code);
+  @Override
+  public String getIdentifier(String idToken, AuthPlatform platform) {
+    return switch (platform) {
+      case APPLE -> appleAuthService.getIdentifierByToken(idToken);
+      case GOOGLE -> googleAuthService.getIdentifierByToken(idToken);
     };
   }
 
-  private String parseAuthPlatformId(IdTokenResponse tokenResponse) {
-    String idToken = tokenResponse.idToken();
+  public String getIdTokenByCode(String authPlatform, String code) {
+    AuthPlatform type = AuthPlatform.find(authPlatform);
+
+    return switch (type) {
+      case APPLE -> appleAuthService.getIdTokenByCode(code).idToken();
+      case GOOGLE -> googleAuthService.getIdTokenByCode(code).idToken();
+    };
+  }
+
+  private String parseAuthPlatformId(String idToken) {
     try {
       SignedJWT signedJWT = SignedJWT.parse(idToken);
       JWTClaimsSet payload = signedJWT.getJWTClaimsSet();

--- a/src/main/java/sopt/makers/authentication/external/oauth/OAuthAuthenticatorImpl.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/OAuthAuthenticatorImpl.java
@@ -37,7 +37,7 @@ public class OAuthAuthenticatorImpl implements OAuthAuthenticator {
     };
   }
 
-  public String getIdTokenByCode(String authPlatform, String code) {
+  private String getIdTokenByCode(String authPlatform, String code) {
     AuthPlatform type = AuthPlatform.find(authPlatform);
 
     return switch (type) {

--- a/src/main/java/sopt/makers/authentication/external/oauth/OAuthAuthenticatorImpl.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/OAuthAuthenticatorImpl.java
@@ -1,11 +1,9 @@
 package sopt.makers.authentication.external.oauth;
 
-import static sopt.makers.authentication.domain.auth.AuthPlatform.APPLE;
-import static sopt.makers.authentication.domain.auth.AuthPlatform.GOOGLE;
 import static sopt.makers.authentication.support.code.external.failure.ClientError.INVALID_ID_TOKEN;
 
 import sopt.makers.authentication.domain.auth.AuthPlatform;
-import sopt.makers.authentication.support.exception.external.*;
+import sopt.makers.authentication.support.exception.external.ClientResponseException;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 
 import java.text.ParseException;

--- a/src/main/java/sopt/makers/authentication/external/oauth/client/AppleAuthClient.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/client/AppleAuthClient.java
@@ -1,0 +1,100 @@
+package sopt.makers.authentication.external.oauth.client;
+
+import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
+import static sopt.makers.authentication.support.constant.OAuthConstant.*;
+
+import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
+import sopt.makers.authentication.support.exception.external.ClientRequestException;
+import sopt.makers.authentication.support.exception.external.ClientResponseException;
+import sopt.makers.authentication.support.util.RequestUtil;
+import sopt.makers.authentication.support.value.AppleOAuthProperty;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+import com.nimbusds.jose.jwk.JWKSet;
+
+import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+
+@Component
+@RequiredArgsConstructor
+public class AppleAuthClient {
+
+  private final AppleOAuthProperty appleOAuthProperty;
+  private final Gson gson;
+  private final OkHttpClient client;
+
+  public IdTokenResponse getIdToken(final String secret, final String code) {
+    Headers header = createTokenRequestHeader();
+    FormBody formBody = createTokenRequestFormBody(secret, code);
+
+    Request tokenRequest = RequestUtil.createPostRequest(APPLE_TOKEN_URL, header, formBody);
+    Response tokenResponse = executeRequest(tokenRequest);
+
+    return parseResponseBody(tokenResponse, IdTokenResponse.class);
+  }
+
+  public JWKSet getPublicKeySet() {
+    try {
+      return JWKSet.load(new URI(APPLE_PUBLIC_KEY_SET_URL).toURL());
+    } catch (URISyntaxException e) {
+      throw new ClientRequestException(INVALID_APPLE_REQUEST_URL);
+    } catch (IOException | ParseException e) {
+      throw new ClientResponseException(APPLE_REQUEST_FAIL);
+    }
+  }
+
+  private Headers createTokenRequestHeader() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(CONTENT_TYPE, CONTENT_TYPE_VALUE);
+    headers.put(ACCEPT, ACCEPT_VALUE);
+    return RequestUtil.createHeaders(headers);
+  }
+
+  private FormBody createTokenRequestFormBody(final String secret, final String code) {
+    String clientId = appleOAuthProperty.sub();
+    return new FormBody.Builder()
+        .add(CLIENT_ID, clientId)
+        .add(CLIENT_SECRET, secret)
+        .add(CODE, code)
+        .add(GRANT_TYPE, GRANT_TYPE_VALUE)
+        .build();
+  }
+
+  private Response executeRequest(Request request) {
+    try {
+      Response response = client.newCall(request).execute();
+
+      validateResponse(response);
+      return response;
+    } catch (IOException e) {
+      throw new ClientResponseException(APPLE_RESPONSE_UNAVAILABLE);
+    }
+  }
+
+  private void validateResponse(Response response) {
+    boolean isNotSuccessResponse = !response.isSuccessful();
+
+    if (isNotSuccessResponse) {
+      throw new ClientRequestException(APPLE_REQUEST_FAIL);
+    }
+  }
+
+  private <T> T parseResponseBody(Response response, Class<T> classOfType) {
+    ResponseBody responseBody = response.body();
+    boolean isBodyNull = responseBody == null;
+
+    if (isBodyNull) {
+      throw new ClientResponseException(APPLE_RESPONSE_UNAVAILABLE);
+    }
+    return gson.fromJson(response.body().toString(), classOfType);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/external/oauth/client/GoogleAuthClient.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/client/GoogleAuthClient.java
@@ -1,0 +1,99 @@
+package sopt.makers.authentication.external.oauth.client;
+
+import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
+import static sopt.makers.authentication.support.constant.OAuthConstant.*;
+
+import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
+import sopt.makers.authentication.support.exception.external.ClientRequestException;
+import sopt.makers.authentication.support.exception.external.ClientResponseException;
+import sopt.makers.authentication.support.util.RequestUtil;
+import sopt.makers.authentication.support.value.GoogleOAuthProperty;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+import com.nimbusds.jose.jwk.JWKSet;
+
+import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleAuthClient {
+  private final GoogleOAuthProperty googleOAuthProperty;
+  private final Gson gson;
+  private final OkHttpClient client;
+
+  public IdTokenResponse getIdToken(final String secret, final String code) {
+    Headers header = createTokenRequestHeader();
+    FormBody formBody = createTokenRequestFormBody(secret, code);
+
+    Request tokenRequest = RequestUtil.createPostRequest(GOOGLE_TOKEN_URL, header, formBody);
+    Response tokenResponse = executeRequest(tokenRequest);
+
+    return parseResponseBody(tokenResponse, IdTokenResponse.class);
+  }
+
+  public JWKSet getPublicKeySet() {
+    try {
+      return JWKSet.load(new URI(GOOGLE_PUBLIC_KEY_SET_URL).toURL());
+    } catch (URISyntaxException e) {
+      throw new ClientRequestException(INVALID_APPLE_REQUEST_URL);
+    } catch (IOException | ParseException e) {
+      throw new ClientResponseException(APPLE_REQUEST_FAIL);
+    }
+  }
+
+  private FormBody createTokenRequestFormBody(String secret, String code) {
+    return new FormBody.Builder()
+        .add(CLIENT_ID, googleOAuthProperty.client().id())
+        .add(CLIENT_SECRET, secret)
+        .add(CODE, code)
+        .add(GRANT_TYPE, GRANT_TYPE_VALUE)
+        .add(REDIRECT_URI, googleOAuthProperty.redirect().url())
+        .build();
+  }
+
+  private Headers createTokenRequestHeader() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(CONTENT_TYPE, CONTENT_TYPE_VALUE);
+    headers.put(ACCEPT, ACCEPT_VALUE);
+    return RequestUtil.createHeaders(headers);
+  }
+
+  private Response executeRequest(Request request) {
+    try {
+      Response response = client.newCall(request).execute();
+
+      validateResponse(response);
+      return response;
+    } catch (IOException e) {
+      throw new ClientResponseException(GOOGLE_RESPONSE_UNAVAILABLE);
+    }
+  }
+
+  private void validateResponse(Response response) {
+    boolean isNotSuccessResponse = !response.isSuccessful();
+
+    if (isNotSuccessResponse) {
+      throw new ClientRequestException(GOOGLE_REQUEST_FAIL);
+    }
+  }
+
+  private <T> T parseResponseBody(Response response, Class<T> classOfType) {
+    ResponseBody responseBody = response.body();
+    boolean isBodyNull = responseBody == null;
+
+    if (isBodyNull) {
+      throw new ClientResponseException(APPLE_RESPONSE_UNAVAILABLE);
+    }
+    return gson.fromJson(response.body().toString(), classOfType);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
@@ -14,10 +14,12 @@ import lombok.RequiredArgsConstructor;
 public enum AuthFailure implements FailureCode {
   // 400
   INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다"),
+  INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "ID 토큰 유효성 검사에 실패했습니다."),
 
   // 404
   NOT_FOUND_PHONE_VERIFICATION(HttpStatus.NOT_FOUND, "존재하지 않는 번호 인증 이력입니다."),
   NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 계정 정보와 일치하는 회원이 없습니다"),
+  NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET(HttpStatus.NOT_FOUND, "유효한 Public Key Set를 찾을 수 없습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/sopt/makers/authentication/support/code/domain/success/AuthSuccess.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/success/AuthSuccess.java
@@ -18,6 +18,7 @@ public enum AuthSuccess implements SuccessCode {
 
   // 201
   CREATE_PHONE_VERIFICATION(HttpStatus.CREATED, "번호 인증 생성에 성공했습니다."),
+  CREATE_SIGN_UP_USER(HttpStatus.CREATED, "회원 가입에 성공했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/sopt/makers/authentication/support/code/external/failure/ClientError.java
+++ b/src/main/java/sopt/makers/authentication/support/code/external/failure/ClientError.java
@@ -15,8 +15,11 @@ public enum ClientError implements FailureCode {
   GABIA_REQUEST_FAIL(HttpStatus.BAD_REQUEST, "Gabia 요청에 실패했습니다."),
   GABIA_RESPONSE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "Gabia 요청 결과 내 의도한 데이터가 없습니다."),
   GABIA_RESPONSE_BIND_FAIL(HttpStatus.BAD_REQUEST, "Gabia 요청 결과 역질렬화에 실패했습니다."),
-  INVALID_APPLE_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple 인증 code 입니다."),
-  INVALID_GOOGLE_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 Google 인증 code 입니다"),
+  APPLE_REQUEST_FAIL(HttpStatus.BAD_REQUEST, "Apple 요청에 실패했습니다."),
+  GOOGLE_REQUEST_FAIL(HttpStatus.BAD_REQUEST, "Google 요청에 실패했습니다."),
+  INVALID_APPLE_REQUEST_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple 요청 URL입니다."),
+  INVALID_APPLE_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple 인증 token 입니다."),
+  INVALID_GOOGLE_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 Google 인증 token 입니다"),
 
   // 500 INTERNAL_SERVER_ERROR
   INVALID_ID_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 id token 입니다."),

--- a/src/main/java/sopt/makers/authentication/support/code/support/failure/TokenFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/support/failure/TokenFailure.java
@@ -12,11 +12,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
 public enum TokenFailure implements FailureCode {
+  TOKEN_PARSE_FAILED(HttpStatus.BAD_REQUEST, "토큰 복호화에 실패했습니다."),
   TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "토큰이 만료되었습니다."),
   UNSUPPORTED_ISSUER(HttpStatus.BAD_REQUEST, "신뢰할 수 없는 발급자입니다."),
   INVALID_PREFIX(HttpStatus.BAD_REQUEST, "토큰 접두사가 잘못되었습니다."),
   INVALID_SIGNATURE(HttpStatus.BAD_REQUEST, "서명이 잘못되었습니다."),
-  ;
   ;
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/sopt/makers/authentication/support/constant/OAuthConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/OAuthConstant.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public final class OAuthConstant {
   public static final String CLIENT_ID = "client_id";
   public static final String CLIENT_SECRET = "client_secret";
-  public static final String CODE = "code";
+  public static final String CODE = "token";
   public static final String GRANT_TYPE = "grant_type";
   public static final String CONTENT_TYPE = "Content-Type";
   public static final String ACCEPT = "Accept";
@@ -17,8 +17,13 @@ public final class OAuthConstant {
   public static final String ACCEPT_VALUE = "application/json";
   public static final String REDIRECT_URI = "redirect_uri";
   public static final String APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token";
+  public static final String APPLE_PUBLIC_KEY_SET_URL = "https://appleid.apple.com/auth/keys";
   public static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+  public static final String GOOGLE_PUBLIC_KEY_SET_URL =
+      "https://www.googleapis.com/oauth2/v3/certs";
   public static final String APPLE_KEY_ID_HEADER = "kid";
   public static final String APPLE_ALGORITHM_HEADER = "alg";
   public static final String APPLE_ALGORITHM_VALUE = "ES256";
+  public static final String APPLE_ISSUER = "https://appleid.apple.com";
+  public static final String GOOGLE_ISSUER = "https://accounts.google.com";
 }

--- a/src/main/java/sopt/makers/authentication/support/util/RequestUtil.java
+++ b/src/main/java/sopt/makers/authentication/support/util/RequestUtil.java
@@ -1,0 +1,22 @@
+package sopt.makers.authentication.support.util;
+
+import java.util.Map;
+
+import okhttp3.Headers;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+public final class RequestUtil {
+
+  public static Request createGetRequest(String url, Headers headers) {
+    return new Request.Builder().url(url).headers(headers).get().build();
+  }
+
+  public static Request createPostRequest(String url, Headers headers, RequestBody body) {
+    return new Request.Builder().url(url).headers(headers).post(body).build();
+  }
+
+  public static Headers createHeaders(Map<String, String> values) {
+    return Headers.of(values);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/in/SignUpUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/in/SignUpUsecase.java
@@ -1,0 +1,10 @@
+package sopt.makers.authentication.usecase.auth.port.in;
+
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+
+public interface SignUpUsecase {
+
+  void signUp(SignUpCommand command);
+
+  record SignUpCommand(String name, String phone, String authCode, AuthPlatform authPlatform) {}
+}

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/in/SignUpUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/in/SignUpUsecase.java
@@ -6,5 +6,5 @@ public interface SignUpUsecase {
 
   void signUp(SignUpCommand command);
 
-  record SignUpCommand(String name, String phone, String authCode, AuthPlatform authPlatform) {}
+  record SignUpCommand(String name, String phone, String token, AuthPlatform authPlatform) {}
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/OAuthAuthenticator.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/OAuthAuthenticator.java
@@ -1,5 +1,9 @@
 package sopt.makers.authentication.usecase.auth.port.out;
 
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+
 public interface OAuthAuthenticator {
   String getAuthPlatformId(String authPlatform, String code);
+
+  String getIdentifier(String idToken, AuthPlatform platform);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
@@ -11,5 +11,7 @@ public interface UserRepository {
 
   Long findIdByUser(User user);
 
+  void save(User user);
+
   User update(Long id, User user, SocialAccount socialAccount);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
@@ -1,0 +1,52 @@
+package sopt.makers.authentication.usecase.auth.service;
+
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Profile;
+import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.domain.user.UserRegisterInfo;
+import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase;
+import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
+import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
+import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpService implements SignUpUsecase {
+  private final OAuthAuthenticator oAuthAuthenticator;
+
+  private final UserRepository userRepository;
+  private final UserRegisterInfoRepository userRegisterInfoRepository;
+
+  @Override
+  public void signUp(SignUpCommand command) {
+    String identifier = oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
+    UserRegisterInfo registerInfo = userRegisterInfoRepository.findByPhone(command.phone());
+
+    SocialAccount socialAccount = createSocialAccount(command.authPlatform(), identifier);
+    Profile profile = createProfile(registerInfo);
+    User newUser = User.createNewUser(socialAccount, profile);
+
+    userRepository.save(newUser);
+    userRegisterInfoRepository.delete(registerInfo);
+  }
+
+  private SocialAccount createSocialAccount(AuthPlatform authPlatform, String identifier) {
+    return switch (authPlatform) {
+      case GOOGLE -> SocialAccount.of(identifier, AuthPlatform.GOOGLE.name());
+      case APPLE -> SocialAccount.of(identifier, AuthPlatform.APPLE.name());
+    };
+  }
+
+  private Profile createProfile(UserRegisterInfo registerInfo) {
+    return Profile.of(
+        registerInfo.getName(),
+        registerInfo.getEmail(),
+        registerInfo.getPhone(),
+        registerInfo.getBirthday());
+  }
+}

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRegisterInfoRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRegisterInfoRepository.java
@@ -5,4 +5,6 @@ import sopt.makers.authentication.domain.user.UserRegisterInfo;
 public interface UserRegisterInfoRepository {
 
   UserRegisterInfo findByPhone(String phone);
+
+  void delete(UserRegisterInfo userRegisterInfo);
 }


### PR DESCRIPTION
## Related Issue 🚀
- closed #16 

<br/>

## Work Description ✏️
회원가입 기능을 구현했습니다.

### ⚙️ 구현 회원 가입 프로세스
각 플랫폼마다의 회원 가입을 분리하여 구현했습니다.

(아래 플랫폼은 `authPlatform` 기준으로 분기 처리됩니다)
- Google
  1. Body - `name`, `phone`, `code`, `authPlatform`
  2. `code`(ID Token) → `https://oauth2.googleapis.com/tokeninfo?id_token=ID_TOKEN` 호출 ([참고 Docs](https://cloud.google.com/docs/authentication/token-types?hl=ko#access))
  3. Unique Identifier `sub` 추출
  4. `name` & `phone` → UserRegisterInfo 저장소에서 사전 제출 인적정보 조회
  5. UserRegisterInfo 데이터 & `sub` 값 기반 신규 회원(`User`) 데이터 생성 및 저장
  6. 완료

- Apple
  1. Body - `name`, `phone`, `code`, `authPlatform`
  2. `code`(ID Token) →  ID Token Parsing
  3. Unique Identifier `sub` 추출
  4. `name` & `phone` → UserRegisterInfo 저장소에서 사전 제출 인적정보 조회
  5. UserRegisterInfo 데이터 & `sub` 값 기반 신규 회원(`User`) 데이터 생성 및 저장
  6. 완료

(참고 Apple Docs : [Authenticating users with Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple), [Verifying a user](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user#3383769), [Generate and validate tokens](https://developer.apple.com/documentation/accountorganizationaldatasharing/generate-and-validate-tokens), [JWKS-Keys](https://developer.apple.com/documentation/accountorganizationaldatasharing/jwkset/jwkset.keys))


위 API의 Request Body로 전달받는`code` 값은 `ID_TOKEN`(`ACCESS_TOKEN` ❌) 입니다.
- [Google 토큰 유형](https://cloud.google.com/docs/authentication/token-types?hl=ko)
- [Apple 토큰 유형](https://developer.apple.com/documentation/accountorganizationaldatasharing/generate-and-validate-tokens)

<br/>

### 🔑 Id Token 검증 방식
- Google ([공식 문서](https://developers.google.com/identity/openid-connect/openid-connect?hl=ko#validatinganidtoken))
  - ID 토큰에 발급자가 올바르게 서명했는지 확인합니다. Google에서 발급한 토큰은 [검색 문서](https://developers.google.com/identity/openid-connect/openid-connect?hl=ko#discovery)의 jwks_uri 메타데이터 값에 지정된 URI에 있는 인증서 중 하나를 사용하여 서명됩니다.
  - ID 토큰의 iss 클레임 값이 https://accounts.google.com 또는 accounts.google.com와 같은지 확인합니다.
  - ID 토큰의 aud 클레임 값이 앱의 클라이언트 ID와 같은지 확인합니다.
  - ID 토큰의 만료 시간 (exp 클레임)이 지났는지 확인합니다.
  - 요청에 [hd 매개변수](https://developers.google.com/identity/openid-connect/openid-connect?hl=ko#hd-param) 값을 지정한 경우 ID 토큰에 Google Cloud 조직과 연결된 허용된 도메인과 일치하는 hd 클레임이 있는지 확인합니다.
- Apple ([공식 문서](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user#3383769))
  - Verify the JWS E256 signature using the server’s public key
  - Verify the nonce for the authentication
  - Verify that the iss field contains https://appleid.apple.com
  - Verify that the aud field is the developer’s client_id
  - Verify that the time is earlier than the exp value of the token

<br/>

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
### ✅ 인증 과정에서 사용되는 객체들의 책임과 역할
과거 첫 구현 당시 워낙 큰 볼륨의 작업이었기에 빠르게 반영하기 어려울 듯 하여 구체적으로 개선안에 대해 제안드리지 못했었는데요!
이번 기능 구현을 진행하면서 혼재되어 있는 역할과 처리로 인해 작업에 어려움이 있었습니다.

> 기존

```
- OAuthAuthenticator
  - 인증 메서드 호출

- AppleAuthService
  - Apple 통신
    - Request 객체 제작
    - Request Header 제작
    - Apple Client Secret JWT 생성
    - Response 파싱
    - Response 검증 (null & 2xx 여부)
  - Apple 검증/인증 처리
- GoogleAuthService
    - Request 객체 제작
    - Request Header 제작
    - Response 파싱
    - Response 검증 (null & 2xx 여부)
  - Google 검증/인증 처리
```

위 구조라면 **각 OAuth 플랫폼에서 요구하는 검증/인증 작업에 대한 구현**은 `xxxAuthService` 객체 내에 **계속해서 구현**해야 하는 상황이었습니다.

<br/>

> 변경

- Domain 레이어에서는 Service 구현체만 주입받아 비즈니즈 요구사항을 위한 행위에 대해서만 알도록 했습니다.
- Port 객체는 플랫폼에 따라 달라지는 맞춤 구현에 대한 책임이 없기 때문에 분리했습니다.
  - 플랫폼과 관계없이 동일한 "인증행위"에 대해서만 호출할 수 있도록 했습니다.
- 인증 작업 객체들은 구체적인 통신 구성 작업에 대한 책임이 없기 때문에 분리했습니다. → 인증 작업만 처리하도록 했습니다.
```
// Domain에서 사용되는 port
- OAuthService (OAuthServiceImpl)
  - 인증 메서드 호출

// 구체적인 각 플랫폼들을 위한 인증 작업 객체
- AppleAuthenticator
  - Apple 측에서 명시한 검증/인증 처리
  - Apple Client Secret JWT 생성
  - 통신 호출
- GoogleAuthenticator
  - Google 측에서 명시한 검증/인증 처리
  - 통신 호출

// 외부 서버 통신 담당 객체
- AppleAuthClient
- GoogleAuthClient
```

조금더 유연하고 확장 및 재사용이 가능하도록 개선할 수 있는 요소가 충분히 더 존재하는 것 같습니다.
(ex. Request / Response / Header 생성 Util 객체 분리 등)

추후에 더 논의해보았으면 좋겠습니다.

<br/>

### ✅ 인증 프로세스 통일화 (웹 ↔ 네이티브앱) 
초반 `access_token`과 `id_token`의 개념이 혼동되어 섣불리 확정 짓기 어려웠는데요.

웹 환경과 네이티브 앱 환경에서 모두 동일한 로그인/회원가입 경험을 제공해야했기 때문에 아래와 같은 고민을 했습니다.
1. 웹과 앱은 서로의 방식에 맞춰 구현하고 서버에서 각 환경에 맞추어 API를 분리한다.
2. 서버에서 단일 API로 통일화하고 웹과 앱에서 해당 API 요구사항에 맞추어 구현한다.

이 때, 추후 "**유지보수성**"와 "**빠른 대응성**"을 위해 **2번 방식이 적합하다고 생각했습니다.**
(웹 클라이언트 전달 : [Configuring your webpage for Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/configuring_your_webpage_for_sign_in_with_apple)

<br/>

### ✅ Access Token ↔️ Id Token
위 언급했듯 2번 방식을 채택함에 따라 각 OAuht 플랫폼의 Token API 공식 문서를 살펴본 결과, 모두 동일하게 `access_token`과 `id_token` 을 사용하는 토큰 정책이 적용되어 있고

기본적으로 회원가입 절차에서 사용할 사용자 식별값은 각 플랫폼의 토큰들에 내제되어 있는 Unique Identifier`sub`를 사용하고자했습니다.
하지만 해당 `sub` 값은 `access_token`과 `id_token` 모두에 포함되어 있습니다.

하지만 각 공식 문서에서 동일하게 얘기하는 내용은 아래와 같았고 이에 따라 **ID Token 사용을 채택했습니다.**
> ※ access token은 각자의 앱에서 검증하는 대상이 아니며 OAuth resource sever에 접근하는 용도로 사용한다.
>
> ※ access token은 불투명 토큰이며, 이는 독점적 형식임을 의미합니다. 애플리케이션이 이를 검사할 수 없습니다.(Google)
>
> ※ 애플리케이션이 검사할 수 없는 불투명 객체인 액세스 토큰과 달리 ID 토큰은 애플리케이션에서 검사하고 사용하도록 되어 있습니다. 토큰에 서명한 사용자 또는 ID 토큰이 발급된 ID와 같은 토큰의 정보가 애플리케이션에서 사용하도록 제공됩니다. (Google)
>
> ※ verify 대상은 JWT로서 사용자의 식별 데이터를 포함한 id token으로 사용한다. (Apple)

<br/>

### ✅ 왜 OAuth 플랫폼 계정의 email은 식별값으로 사용하지 않는가
해당 내용은 Google보다는 Apple의 영향이 큽니다.
Apple의 [공식 문서](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple#3383773)에 따르면 아래와 같이 전했습니다.

> 사용자의 이메일 주소를 나타내는 문자열 값입니다. 이메일 주소는 사용자의 개인 이메일 중계 서비스에 따라 사용자의 실제 이메일 주소 또는 프록시 주소입니다. 직장 및 학교의 Apple로 로그인 사용자의 경우 이 값은 비어 있을 수 있습니다. 예를 들어, 어린 학생의 경우 이메일 주소가 없을 수 있습니다.

![image](https://github.com/user-attachments/assets/3b0459e7-4d9c-47df-ae08-0df972de6557)
![image](https://github.com/user-attachments/assets/31296c79-71d8-4799-8758-1ef8a08a517f)

위와 같이 학교 계정/직장 계정에 대해 불확실성을 가지고 있었기에 필수 식별값으로 사용하기엔 부적합하다고 판단했습니다.
(물론 Apple에서도 private proxy email을 email로 변환하는 방식도 제공하지만 이를 위한 클라이언트와 서버의 추가적인 구현은 비효율적일 것이라고 판단했습니다.)


<br/>

### 🤯 도메인 객체의 ID 부재 해결방법...
레퍼런스를 찾아보니 비슷한 고민을 겪은 케이스가 많은 것 같아요.
이에 몇 가지 대안을 찾아왔습니다.

1. 도메인 객체에서 ID를 포함하도록 설계 변경
2. Aggregate Root 도입

추가적인 내용에 대해서는 BE 정기회의 때 얘기나눠보도록 해요!