### PR TITLE
[FEAT/#31] 토큰 Refresh API 구현

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
@@ -19,5 +19,9 @@ public interface AuthApi {
   ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
       AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
 
-  ResponseEntity<BaseResponse<?>> refreshToken(AuthRequest.AuthenticationTokenInfo tokenInfo);
+  ResponseEntity<BaseResponse<?>> refreshTokenFromApp(
+      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo);
+
+  ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(
+      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo);
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
@@ -4,6 +4,7 @@ import sopt.makers.authentication.application.auth.dto.request.AuthRequest;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 public interface AuthApi {
 
@@ -23,5 +24,6 @@ public interface AuthApi {
       AuthRequest.AuthenticationTokenInfo authenticationTokenInfo);
 
   ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(
-      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo);
+      @RequestHeader("accessToken") String accessToken,
+      @RequestHeader("refreshToken") String refreshToken);
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApi.java
@@ -18,4 +18,6 @@ public interface AuthApi {
 
   ResponseEntity<BaseResponse<?>> authenticateSocialAuthInfoFromApp(
       AuthRequest.AuthenticateSocialAuthInfo socialAuthInfo);
+
+  ResponseEntity<BaseResponse<?>> refreshToken(AuthRequest.AuthenticationTokenInfo tokenInfo);
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -74,4 +74,18 @@ public class AuthApiController implements AuthApi {
         AuthResponse.AuthenticateSocialAuthInfoForApp.of(
             tokenInfo.accessToken(), tokenInfo.refreshToken()));
   }
+
+  @Override
+  @PostMapping("/refresh")
+  public ResponseEntity<BaseResponse<?>> refreshToken(
+      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo) {
+
+    AuthenticateTokenInfo tokenInfo =
+        authenticateSocialAccountUsecase.refresh(authenticationTokenInfo.toCommand());
+
+    return ResponseUtil.success(
+        AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
+        AuthResponse.AuthenticateSocialAuthInfo.of(
+            tokenInfo.accessToken(), tokenInfo.refreshToken()));
+  }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -76,8 +76,8 @@ public class AuthApiController implements AuthApi {
   }
 
   @Override
-  @PostMapping("/refresh")
-  public ResponseEntity<BaseResponse<?>> refreshToken(
+  @PostMapping("/refresh/app")
+  public ResponseEntity<BaseResponse<?>> refreshTokenFromApp(
       AuthRequest.AuthenticationTokenInfo authenticationTokenInfo) {
 
     AuthenticateTokenInfo tokenInfo =
@@ -87,5 +87,20 @@ public class AuthApiController implements AuthApi {
         AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
         AuthResponse.AuthenticateSocialAuthInfo.of(
             tokenInfo.accessToken(), tokenInfo.refreshToken()));
+  }
+
+  @Override
+  @PostMapping("/refresh/web")
+  public ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(
+      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo) {
+
+    AuthenticateTokenInfo tokenInfo =
+        authenticateSocialAccountUsecase.refresh(authenticationTokenInfo.toCommand());
+    HttpHeaders headers = cookieUtil.setRefreshToken(tokenInfo.refreshToken());
+
+    return ResponseUtil.success(
+        AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
+        headers,
+        AuthResponse.AuthenticateSocialAuthInfoForWeb.of(tokenInfo.accessToken()));
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -85,14 +86,18 @@ public class AuthApiController implements AuthApi {
 
     return ResponseUtil.success(
         AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
-        AuthResponse.AuthenticateSocialAuthInfo.of(
+        AuthResponse.AuthenticateSocialAuthInfoForApp.of(
             tokenInfo.accessToken(), tokenInfo.refreshToken()));
   }
 
   @Override
   @PostMapping("/refresh/web")
   public ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(
-      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo) {
+      @RequestHeader("accessToken") String accessToken,
+      @RequestHeader("refreshToken") String refreshToken) {
+
+    AuthRequest.AuthenticationTokenInfo authenticationTokenInfo =
+        new AuthRequest.AuthenticationTokenInfo(accessToken, refreshToken);
 
     AuthenticateTokenInfo tokenInfo =
         authenticateSocialAccountUsecase.refresh(authenticationTokenInfo.toCommand());

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
@@ -4,6 +4,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase.AuthenticateSocialAccountCommand;
+import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase.AuthenticateTokenInfo;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase.CreateVerificationCommand;
 import sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase.VerifyVerificationCommand;
 
@@ -41,6 +42,12 @@ public final class AuthRequest {
   public record AuthenticateSocialAuthInfo(String code, String authPlatform) {
     public AuthenticateSocialAccountCommand toCommand() {
       return AuthenticateSocialAccountCommand.of(authPlatform, code);
+    }
+  }
+
+  public record AuthenticationTokenInfo(String accessToken, String refreshToken) {
+    public AuthenticateTokenInfo toCommand() {
+      return AuthenticateTokenInfo.of(accessToken, refreshToken);
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
@@ -34,6 +34,12 @@ public final class AuthResponse {
     }
   }
 
+  public record AuthenticateSocialAuthInfo(String accessToken, String refreshToken) {
+    public static AuthenticateSocialAuthInfo of(String accessToken, String refreshToken) {
+      return new AuthenticateSocialAuthInfo(accessToken, refreshToken);
+    }
+  }
+
   public record SocialAccountPlatform(@JsonProperty("platform") String platformName) {
     public static SocialAccountPlatform from(
         GetSocialAccountUsecase.SocialAccountPlatformInfo info) {

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
@@ -34,12 +34,6 @@ public final class AuthResponse {
     }
   }
 
-  public record AuthenticateSocialAuthInfo(String accessToken, String refreshToken) {
-    public static AuthenticateSocialAuthInfo of(String accessToken, String refreshToken) {
-      return new AuthenticateSocialAuthInfo(accessToken, refreshToken);
-    }
-  }
-
   public record SocialAccountPlatform(@JsonProperty("platform") String platformName) {
     public static SocialAccountPlatform from(
         GetSocialAccountUsecase.SocialAccountPlatformInfo info) {

--- a/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthAccessTokenProvider.java
+++ b/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthAccessTokenProvider.java
@@ -8,7 +8,6 @@ import sopt.makers.authentication.support.jwt.token.JwtAccessToken;
 import sopt.makers.authentication.support.security.authentication.CustomAuthentication;
 import sopt.makers.authentication.support.value.JwtProperty;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,7 +52,7 @@ public class JwtAuthAccessTokenProvider implements JwtProvider<CustomAuthenticat
   }
 
   @Override
-  public CustomAuthentication parse(String requestToken) throws IOException {
+  public CustomAuthentication parse(String requestToken) {
     String token = extract(requestToken);
     Jwt accessToken = jwtDecoder.decode(token);
     JwtAccessToken jwtAccessToken = JwtAccessToken.createJwtAccessToken(accessToken);

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/in/AuthenticateSocialAccountUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/in/AuthenticateSocialAccountUsecase.java
@@ -3,6 +3,8 @@ package sopt.makers.authentication.usecase.auth.port.in;
 public interface AuthenticateSocialAccountUsecase {
   AuthenticateTokenInfo authenticate(AuthenticateSocialAccountCommand command);
 
+  AuthenticateTokenInfo refresh(AuthenticateTokenInfo command);
+
   record AuthenticateTokenInfo(String accessToken, String refreshToken) {
     public static AuthenticateTokenInfo of(String accessToken, String refreshToken) {
       return new AuthenticateTokenInfo(accessToken, refreshToken);

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -39,4 +39,15 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
 
     return AuthenticateTokenInfo.of(accessToken, refreshToken);
   }
+
+  @Override
+  public AuthenticateTokenInfo refresh(AuthenticateTokenInfo command) {
+    String refreshToken = command.refreshToken();
+    jwtAuthRefreshTokenProvider.parse(refreshToken);
+    CustomAuthentication customAuthentication =
+        jwtAuthAccessTokenProvider.parse(command.accessToken());
+    String renewedAccessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
+    String renewedRefreshToken = jwtAuthRefreshTokenProvider.generate(renewedAccessToken);
+    return AuthenticateTokenInfo.of(renewedAccessToken, renewedRefreshToken);
+  }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -43,9 +43,11 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
   @Override
   public AuthenticateTokenInfo refresh(AuthenticateTokenInfo command) {
     String refreshToken = command.refreshToken();
+
     jwtAuthRefreshTokenProvider.parse(refreshToken);
     CustomAuthentication customAuthentication =
         jwtAuthAccessTokenProvider.parse(command.accessToken());
+
     String renewedAccessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
     String renewedRefreshToken = jwtAuthRefreshTokenProvider.generate(renewedAccessToken);
     return AuthenticateTokenInfo.of(renewedAccessToken, renewedRefreshToken);


### PR DESCRIPTION
## Related Issue 🚀
- closed #31

## Work Description ✏️
- 토큰 refresh API 를 구현했습니다. 

## PR Point 📸

1. 클라이언트가 토큰 만료 결과를 받는다. 
2. 토큰 Refresh 호출 
3. RefreshToken parse 및 검증
4. 실패 시 ( 만료, 기타 등등 ) 예외 반환
5. 성공 시 refreshToken 갱신
6. 갱신된 RefreshToken을 이용해 accessToken 갱신 후 반환

이 전체적인 로직입니다. 

성은이가 만들어놓은 AuthenticateTokenInfo 랑 AuthenticationTokenInfo가 헷갈려서 착오가 있을 수 있지만..
혹시 오류 있다면 리뷰로 달아주시면 감사하겠습니다 ! 
