### PR TITLE
[FEAT/#33] 소셜 로그인, 계정 변경하기 API의 oauth 인증 과정 변경

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/request/AuthRequest.java
@@ -40,9 +40,10 @@ public final class AuthRequest {
     }
   }
 
-  public record AuthenticateSocialAuthInfo(String code, String authPlatform) {
+  public record AuthenticateSocialAuthInfo(
+      @JsonProperty("token") String token, @JsonProperty("authPlatform") String authPlatform) {
     public AuthenticateSocialAccountCommand toCommand() {
-      return AuthenticateSocialAccountCommand.of(authPlatform, code);
+      return AuthenticateSocialAccountCommand.of(this.token, AuthPlatform.find(this.authPlatform));
     }
   }
 

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/request/SocialAccountRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/request/SocialAccountRequest.java
@@ -2,15 +2,16 @@ package sopt.makers.authentication.application.auth.dto.request;
 
 import static lombok.AccessLevel.PRIVATE;
 
+import sopt.makers.authentication.domain.auth.*;
 import sopt.makers.authentication.usecase.auth.port.in.UpdateSocialAccountUsecase.UpdateSocialAccountCommand;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = PRIVATE)
 public final class SocialAccountRequest {
-  public record UpdateSocialAccount(String phone, String code, String authPlatform) {
+  public record UpdateSocialAccount(String phone, String token, String authPlatform) {
     public UpdateSocialAccountCommand toCommand() {
-      return UpdateSocialAccountCommand.of(phone, authPlatform, code);
+      return UpdateSocialAccountCommand.of(phone, token, AuthPlatform.find(authPlatform));
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/entity/UserEntity.java
@@ -83,7 +83,7 @@ public class UserEntity extends BaseEntity {
   }
 
   public User toDomain() {
-    SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType.name());
+    SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType);
     Profile profile = Profile.of(name, email, phone, birthday);
     return User.createNewUser(socialAccount, profile);
   }

--- a/src/main/java/sopt/makers/authentication/domain/auth/SocialAccount.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/SocialAccount.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record SocialAccount(
     @NotNull String authPlatformId, @NotNull AuthPlatform authPlatformType) {
-  public static SocialAccount of(final String authPlatformId, final String authPlatformType) {
-    return new SocialAccount(authPlatformId, AuthPlatform.find(authPlatformType));
+  public static SocialAccount of(final String authPlatformId, final AuthPlatform authPlatformType) {
+    return new SocialAccount(authPlatformId, authPlatformType);
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
@@ -7,7 +7,6 @@ import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_IS
 import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_KEY_ID_HEADER;
 
 import sopt.makers.authentication.external.oauth.client.AppleAuthClient;
-import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
 import sopt.makers.authentication.support.code.domain.failure.AuthFailure;
 import sopt.makers.authentication.support.code.support.failure.TokenFailure;
 import sopt.makers.authentication.support.exception.domain.AuthException;
@@ -44,11 +43,6 @@ public class AppleAuthService implements OAuthService {
   private final AppleAuthClient appleAuthClient;
 
   @Override
-  public IdTokenResponse getIdTokenByCode(final String code) {
-    String clientSecret = createClientSecret();
-    return appleAuthClient.getIdToken(clientSecret, code);
-  }
-
   public String getIdentifierByToken(final String token) {
     try {
       SignedJWT signedJWT = SignedJWT.parse(token);

--- a/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
@@ -96,7 +96,7 @@ public class AppleAuthService implements OAuthService {
         KeyFileUtil.getPrivateKey(appleOAuthProperty.key().path())
             .orElseThrow(() -> new ClientRequestException(FAIL_READ_APPLE_PRIVATE_KEY_FILE));
 
-    return Jwts.builder() // 토큰 생성 로직은 tokenProvider? 근데 얘는 parse는 없음
+    return Jwts.builder()
         .setHeaderParam(APPLE_KEY_ID_HEADER, appleOAuthProperty.key().id())
         .setHeaderParam(APPLE_ALGORITHM_HEADER, APPLE_ALGORITHM_VALUE)
         .setIssuedAt(now)

--- a/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
@@ -1,21 +1,16 @@
 package sopt.makers.authentication.external.oauth;
 
 import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
-import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_ALGORITHM_HEADER;
-import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_ALGORITHM_VALUE;
 import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_ISSUER;
-import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_KEY_ID_HEADER;
 
 import sopt.makers.authentication.external.oauth.client.AppleAuthClient;
 import sopt.makers.authentication.support.code.domain.failure.AuthFailure;
 import sopt.makers.authentication.support.code.support.failure.TokenFailure;
 import sopt.makers.authentication.support.exception.domain.AuthException;
-import sopt.makers.authentication.support.exception.external.ClientRequestException;
 import sopt.makers.authentication.support.exception.support.TokenException;
 import sopt.makers.authentication.support.util.*;
 import sopt.makers.authentication.support.value.AppleOAuthProperty;
 
-import java.security.PrivateKey;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.Date;
@@ -30,8 +25,6 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -81,24 +74,5 @@ public class AppleAuthService implements OAuthService {
     } catch (JOSEException e) {
       throw new AuthException(AuthFailure.INVALID_ID_TOKEN);
     }
-  }
-
-  // TODO : AuthXXX 객체에서 ClientXXXException 발생하는 구조는 개선되면 좋을 것 같습니다. (@동규)
-  private String createClientSecret() {
-    Date now = new Date();
-    PrivateKey privateKey =
-        KeyFileUtil.getPrivateKey(appleOAuthProperty.key().path())
-            .orElseThrow(() -> new ClientRequestException(FAIL_READ_APPLE_PRIVATE_KEY_FILE));
-
-    return Jwts.builder()
-        .setHeaderParam(APPLE_KEY_ID_HEADER, appleOAuthProperty.key().id())
-        .setHeaderParam(APPLE_ALGORITHM_HEADER, APPLE_ALGORITHM_VALUE)
-        .setIssuedAt(now)
-        .setExpiration(new Date(now.getTime() + appleOAuthProperty.expiration().tokenExpiration()))
-        .setIssuer(appleOAuthProperty.team().id())
-        .setAudience(appleOAuthProperty.aud())
-        .setSubject(appleOAuthProperty.sub())
-        .signWith(privateKey, SignatureAlgorithm.ES256)
-        .compact();
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
@@ -3,7 +3,6 @@ package sopt.makers.authentication.external.oauth;
 import static sopt.makers.authentication.support.constant.OAuthConstant.*;
 
 import sopt.makers.authentication.external.oauth.client.GoogleAuthClient;
-import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
 import sopt.makers.authentication.support.code.domain.failure.AuthFailure;
 import sopt.makers.authentication.support.code.support.failure.TokenFailure;
 import sopt.makers.authentication.support.exception.domain.AuthException;
@@ -33,10 +32,6 @@ public class GoogleAuthService implements OAuthService {
   private final GoogleAuthClient googleAuthClient;
 
   @Override
-  public IdTokenResponse getIdTokenByCode(String code) {
-    return googleAuthClient.getIdToken(googleOAuthProperty.client().secret(), code);
-  }
-
   public String getIdentifierByToken(final String token) {
     try {
       SignedJWT signedJWT = SignedJWT.parse(token);

--- a/src/main/java/sopt/makers/authentication/external/oauth/OAuthAuthenticatorImpl.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/OAuthAuthenticatorImpl.java
@@ -1,17 +1,9 @@
 package sopt.makers.authentication.external.oauth;
 
-import static sopt.makers.authentication.support.code.external.failure.ClientError.INVALID_ID_TOKEN;
-
 import sopt.makers.authentication.domain.auth.AuthPlatform;
-import sopt.makers.authentication.support.exception.external.ClientResponseException;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 
-import java.text.ParseException;
-
 import org.springframework.stereotype.Component;
-
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,36 +14,10 @@ public class OAuthAuthenticatorImpl implements OAuthAuthenticator {
   private final GoogleAuthService googleAuthService;
 
   @Override
-  public String getAuthPlatformId(String authPlatform, String code) {
-    String idToken = getIdTokenByCode(authPlatform, code);
-    return parseAuthPlatformId(idToken);
-  }
-
-  @Override
   public String getIdentifier(String idToken, AuthPlatform platform) {
     return switch (platform) {
       case APPLE -> appleAuthService.getIdentifierByToken(idToken);
       case GOOGLE -> googleAuthService.getIdentifierByToken(idToken);
     };
-  }
-
-  private String getIdTokenByCode(String authPlatform, String code) {
-    AuthPlatform type = AuthPlatform.find(authPlatform);
-
-    return switch (type) {
-      case APPLE -> appleAuthService.getIdTokenByCode(code).idToken();
-      case GOOGLE -> googleAuthService.getIdTokenByCode(code).idToken();
-    };
-  }
-
-  private String parseAuthPlatformId(String idToken) {
-    try {
-      SignedJWT signedJWT = SignedJWT.parse(idToken);
-      JWTClaimsSet payload = signedJWT.getJWTClaimsSet();
-
-      return payload.getSubject();
-    } catch (ParseException e) {
-      throw new ClientResponseException(INVALID_ID_TOKEN);
-    }
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/OAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/OAuthService.java
@@ -1,7 +1,5 @@
 package sopt.makers.authentication.external.oauth;
 
-import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
-
 public interface OAuthService {
-  IdTokenResponse getIdTokenByCode(String code);
+  String getIdentifierByToken(String token);
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/client/AppleAuthClient.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/client/AppleAuthClient.java
@@ -3,44 +3,23 @@ package sopt.makers.authentication.external.oauth.client;
 import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
 import static sopt.makers.authentication.support.constant.OAuthConstant.*;
 
-import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
 import sopt.makers.authentication.support.exception.external.ClientRequestException;
 import sopt.makers.authentication.support.exception.external.ClientResponseException;
-import sopt.makers.authentication.support.util.RequestUtil;
-import sopt.makers.authentication.support.value.AppleOAuthProperty;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
-import com.google.gson.Gson;
 import com.nimbusds.jose.jwk.JWKSet;
 
 import lombok.RequiredArgsConstructor;
-import okhttp3.*;
 
 @Component
 @RequiredArgsConstructor
 public class AppleAuthClient {
-
-  private final AppleOAuthProperty appleOAuthProperty;
-  private final Gson gson;
-  private final OkHttpClient client;
-
-  public IdTokenResponse getIdToken(final String secret, final String code) {
-    Headers header = createTokenRequestHeader();
-    FormBody formBody = createTokenRequestFormBody(secret, code);
-
-    Request tokenRequest = RequestUtil.createPostRequest(APPLE_TOKEN_URL, header, formBody);
-    Response tokenResponse = executeRequest(tokenRequest);
-
-    return parseResponseBody(tokenResponse, IdTokenResponse.class);
-  }
 
   public JWKSet getPublicKeySet() {
     try {
@@ -50,51 +29,5 @@ public class AppleAuthClient {
     } catch (IOException | ParseException e) {
       throw new ClientResponseException(APPLE_REQUEST_FAIL);
     }
-  }
-
-  private Headers createTokenRequestHeader() {
-    Map<String, String> headers = new HashMap<>();
-    headers.put(CONTENT_TYPE, CONTENT_TYPE_VALUE);
-    headers.put(ACCEPT, ACCEPT_VALUE);
-    return RequestUtil.createHeaders(headers);
-  }
-
-  private FormBody createTokenRequestFormBody(final String secret, final String code) {
-    String clientId = appleOAuthProperty.sub();
-    return new FormBody.Builder()
-        .add(CLIENT_ID, clientId)
-        .add(CLIENT_SECRET, secret)
-        .add(CODE, code)
-        .add(GRANT_TYPE, GRANT_TYPE_VALUE)
-        .build();
-  }
-
-  private Response executeRequest(Request request) {
-    try {
-      Response response = client.newCall(request).execute();
-
-      validateResponse(response);
-      return response;
-    } catch (IOException e) {
-      throw new ClientResponseException(APPLE_RESPONSE_UNAVAILABLE);
-    }
-  }
-
-  private void validateResponse(Response response) {
-    boolean isNotSuccessResponse = !response.isSuccessful();
-
-    if (isNotSuccessResponse) {
-      throw new ClientRequestException(APPLE_REQUEST_FAIL);
-    }
-  }
-
-  private <T> T parseResponseBody(Response response, Class<T> classOfType) {
-    ResponseBody responseBody = response.body();
-    boolean isBodyNull = responseBody == null;
-
-    if (isBodyNull) {
-      throw new ClientResponseException(APPLE_RESPONSE_UNAVAILABLE);
-    }
-    return gson.fromJson(response.body().toString(), classOfType);
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/client/GoogleAuthClient.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/client/GoogleAuthClient.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component;
 import com.nimbusds.jose.jwk.JWKSet;
 
 import lombok.RequiredArgsConstructor;
-import okhttp3.*;
 
 @Component
 @RequiredArgsConstructor
@@ -26,9 +25,9 @@ public class GoogleAuthClient {
     try {
       return JWKSet.load(new URI(GOOGLE_PUBLIC_KEY_SET_URL).toURL());
     } catch (URISyntaxException e) {
-      throw new ClientRequestException(INVALID_APPLE_REQUEST_URL);
+      throw new ClientRequestException(INVALID_GOOGLE_REQUEST_URL);
     } catch (IOException | ParseException e) {
-      throw new ClientResponseException(APPLE_REQUEST_FAIL);
+      throw new ClientResponseException(GOOGLE_REQUEST_FAIL);
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/client/GoogleAuthClient.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/client/GoogleAuthClient.java
@@ -3,22 +3,16 @@ package sopt.makers.authentication.external.oauth.client;
 import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
 import static sopt.makers.authentication.support.constant.OAuthConstant.*;
 
-import sopt.makers.authentication.external.oauth.dto.IdTokenResponse;
 import sopt.makers.authentication.support.exception.external.ClientRequestException;
 import sopt.makers.authentication.support.exception.external.ClientResponseException;
-import sopt.makers.authentication.support.util.RequestUtil;
-import sopt.makers.authentication.support.value.GoogleOAuthProperty;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
-import com.google.gson.Gson;
 import com.nimbusds.jose.jwk.JWKSet;
 
 import lombok.RequiredArgsConstructor;
@@ -27,19 +21,6 @@ import okhttp3.*;
 @Component
 @RequiredArgsConstructor
 public class GoogleAuthClient {
-  private final GoogleOAuthProperty googleOAuthProperty;
-  private final Gson gson;
-  private final OkHttpClient client;
-
-  public IdTokenResponse getIdToken(final String secret, final String code) {
-    Headers header = createTokenRequestHeader();
-    FormBody formBody = createTokenRequestFormBody(secret, code);
-
-    Request tokenRequest = RequestUtil.createPostRequest(GOOGLE_TOKEN_URL, header, formBody);
-    Response tokenResponse = executeRequest(tokenRequest);
-
-    return parseResponseBody(tokenResponse, IdTokenResponse.class);
-  }
 
   public JWKSet getPublicKeySet() {
     try {
@@ -49,51 +30,5 @@ public class GoogleAuthClient {
     } catch (IOException | ParseException e) {
       throw new ClientResponseException(APPLE_REQUEST_FAIL);
     }
-  }
-
-  private FormBody createTokenRequestFormBody(String secret, String code) {
-    return new FormBody.Builder()
-        .add(CLIENT_ID, googleOAuthProperty.client().id())
-        .add(CLIENT_SECRET, secret)
-        .add(CODE, code)
-        .add(GRANT_TYPE, GRANT_TYPE_VALUE)
-        .add(REDIRECT_URI, googleOAuthProperty.redirect().url())
-        .build();
-  }
-
-  private Headers createTokenRequestHeader() {
-    Map<String, String> headers = new HashMap<>();
-    headers.put(CONTENT_TYPE, CONTENT_TYPE_VALUE);
-    headers.put(ACCEPT, ACCEPT_VALUE);
-    return RequestUtil.createHeaders(headers);
-  }
-
-  private Response executeRequest(Request request) {
-    try {
-      Response response = client.newCall(request).execute();
-
-      validateResponse(response);
-      return response;
-    } catch (IOException e) {
-      throw new ClientResponseException(GOOGLE_RESPONSE_UNAVAILABLE);
-    }
-  }
-
-  private void validateResponse(Response response) {
-    boolean isNotSuccessResponse = !response.isSuccessful();
-
-    if (isNotSuccessResponse) {
-      throw new ClientRequestException(GOOGLE_REQUEST_FAIL);
-    }
-  }
-
-  private <T> T parseResponseBody(Response response, Class<T> classOfType) {
-    ResponseBody responseBody = response.body();
-    boolean isBodyNull = responseBody == null;
-
-    if (isBodyNull) {
-      throw new ClientResponseException(APPLE_RESPONSE_UNAVAILABLE);
-    }
-    return gson.fromJson(response.body().toString(), classOfType);
   }
 }

--- a/src/main/java/sopt/makers/authentication/external/oauth/dto/IdTokenResponse.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/dto/IdTokenResponse.java
@@ -1,7 +1,0 @@
-package sopt.makers.authentication.external.oauth.dto;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-public record IdTokenResponse(@JsonProperty("id_token") String idToken) {}

--- a/src/main/java/sopt/makers/authentication/support/code/external/failure/ClientError.java
+++ b/src/main/java/sopt/makers/authentication/support/code/external/failure/ClientError.java
@@ -19,6 +19,7 @@ public enum ClientError implements FailureCode {
   GOOGLE_REQUEST_FAIL(HttpStatus.BAD_REQUEST, "Google 요청에 실패했습니다."),
   INVALID_APPLE_REQUEST_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple 요청 URL입니다."),
   INVALID_APPLE_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple 인증 token 입니다."),
+  INVALID_GOOGLE_REQUEST_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple 요청 URL입니다."),
   INVALID_GOOGLE_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 Google 인증 token 입니다"),
 
   // 500 INTERNAL_SERVER_ERROR

--- a/src/main/java/sopt/makers/authentication/support/constant/OAuthConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/OAuthConstant.java
@@ -6,24 +6,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = PRIVATE)
 public final class OAuthConstant {
-  public static final String CLIENT_ID = "client_id";
-  public static final String CLIENT_SECRET = "client_secret";
-  public static final String CODE = "token";
-  public static final String GRANT_TYPE = "grant_type";
-  public static final String CONTENT_TYPE = "Content-Type";
-  public static final String ACCEPT = "Accept";
-  public static final String GRANT_TYPE_VALUE = "authorization_code";
-  public static final String CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded";
-  public static final String ACCEPT_VALUE = "application/json";
-  public static final String REDIRECT_URI = "redirect_uri";
-  public static final String APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token";
   public static final String APPLE_PUBLIC_KEY_SET_URL = "https://appleid.apple.com/auth/keys";
-  public static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
   public static final String GOOGLE_PUBLIC_KEY_SET_URL =
       "https://www.googleapis.com/oauth2/v3/certs";
-  public static final String APPLE_KEY_ID_HEADER = "kid";
-  public static final String APPLE_ALGORITHM_HEADER = "alg";
-  public static final String APPLE_ALGORITHM_VALUE = "ES256";
   public static final String APPLE_ISSUER = "https://appleid.apple.com";
   public static final String GOOGLE_ISSUER = "https://accounts.google.com";
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/in/AuthenticateSocialAccountUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/in/AuthenticateSocialAccountUsecase.java
@@ -1,5 +1,7 @@
 package sopt.makers.authentication.usecase.auth.port.in;
 
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+
 public interface AuthenticateSocialAccountUsecase {
   AuthenticateTokenInfo authenticate(AuthenticateSocialAccountCommand command);
 
@@ -9,9 +11,9 @@ public interface AuthenticateSocialAccountUsecase {
     }
   }
 
-  record AuthenticateSocialAccountCommand(String authPlatform, String code) {
-    public static AuthenticateSocialAccountCommand of(String authPlatform, String code) {
-      return new AuthenticateSocialAccountCommand(authPlatform, code);
+  record AuthenticateSocialAccountCommand(String token, AuthPlatform authPlatform) {
+    public static AuthenticateSocialAccountCommand of(String token, AuthPlatform authPlatform) {
+      return new AuthenticateSocialAccountCommand(token, authPlatform);
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/in/UpdateSocialAccountUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/in/UpdateSocialAccountUsecase.java
@@ -1,11 +1,14 @@
 package sopt.makers.authentication.usecase.auth.port.in;
 
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+
 public interface UpdateSocialAccountUsecase {
   boolean update(UpdateSocialAccountCommand command);
 
-  record UpdateSocialAccountCommand(String phone, String authPlatform, String code) {
-    public static UpdateSocialAccountCommand of(String phone, String authPlatform, String code) {
-      return new UpdateSocialAccountCommand(phone, authPlatform, code);
+  record UpdateSocialAccountCommand(String phone, String token, AuthPlatform authPlatform) {
+    public static UpdateSocialAccountCommand of(
+        String phone, String token, AuthPlatform authPlatform) {
+      return new UpdateSocialAccountCommand(phone, token, authPlatform);
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/OAuthAuthenticator.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/OAuthAuthenticator.java
@@ -3,7 +3,5 @@ package sopt.makers.authentication.usecase.auth.port.out;
 import sopt.makers.authentication.domain.auth.AuthPlatform;
 
 public interface OAuthAuthenticator {
-  String getAuthPlatformId(String authPlatform, String code);
-
   String getIdentifier(String idToken, AuthPlatform platform);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -27,7 +27,7 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
   @Override
   public AuthenticateTokenInfo authenticate(AuthenticateSocialAccountCommand command) {
     String authPlatformId =
-        oAuthAuthenticator.getAuthPlatformId(command.authPlatform(), command.code());
+        oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     User user =
         userRepository.findBySocialAccount(
             SocialAccount.of(authPlatformId, command.authPlatform()));

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
@@ -24,10 +24,11 @@ public class SignUpService implements SignUpUsecase {
 
   @Override
   public void signUp(SignUpCommand command) {
-    String identifier = oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
+    String authPlatformId =
+        oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     UserRegisterInfo registerInfo = userRegisterInfoRepository.findByPhone(command.phone());
 
-    SocialAccount socialAccount = createSocialAccount(command.authPlatform(), identifier);
+    SocialAccount socialAccount = createSocialAccount(authPlatformId, command.authPlatform());
     Profile profile = createProfile(registerInfo);
     User newUser = User.createNewUser(socialAccount, profile);
 
@@ -35,10 +36,10 @@ public class SignUpService implements SignUpUsecase {
     userRegisterInfoRepository.delete(registerInfo);
   }
 
-  private SocialAccount createSocialAccount(AuthPlatform authPlatform, String identifier) {
+  private SocialAccount createSocialAccount(String authPlatformId, AuthPlatform authPlatform) {
     return switch (authPlatform) {
-      case GOOGLE -> SocialAccount.of(identifier, AuthPlatform.GOOGLE);
-      case APPLE -> SocialAccount.of(identifier, AuthPlatform.APPLE);
+      case GOOGLE -> SocialAccount.of(authPlatformId, AuthPlatform.GOOGLE);
+      case APPLE -> SocialAccount.of(authPlatformId, AuthPlatform.APPLE);
     };
   }
 

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
@@ -37,8 +37,8 @@ public class SignUpService implements SignUpUsecase {
 
   private SocialAccount createSocialAccount(AuthPlatform authPlatform, String identifier) {
     return switch (authPlatform) {
-      case GOOGLE -> SocialAccount.of(identifier, AuthPlatform.GOOGLE.name());
-      case APPLE -> SocialAccount.of(identifier, AuthPlatform.APPLE.name());
+      case GOOGLE -> SocialAccount.of(identifier, AuthPlatform.GOOGLE);
+      case APPLE -> SocialAccount.of(identifier, AuthPlatform.APPLE);
     };
   }
 

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/UpdateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/UpdateSocialAccountService.java
@@ -21,7 +21,7 @@ public class UpdateSocialAccountService implements UpdateSocialAccountUsecase {
     User user = userRepository.findByPhone(command.phone());
     Long userId = userRepository.findIdByUser(user);
     String authPlatformId =
-        oAuthAuthenticator.getAuthPlatformId(command.authPlatform(), command.code());
+        oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     SocialAccount updatedSocialAccount = SocialAccount.of(authPlatformId, command.authPlatform());
     userRepository.update(userId, user, updatedSocialAccount);
     return true;


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #33

## Work Description ✏️
1. code와 token의 혼재
- 동규오빠가 바쁘신 것 같아서 그냥 token으로 모두 통일했습니다!
> pr에도 code라고 적어주셨는데 프로젝트 코드에는 token으로 되어있더라고요 리뷰 과정에서 꼼꼼하게 확인하지 못해 죄송합니다
- 하나의 개념에 대해 여러개의 변수명이 사용되는 것은 좋지 못하다고 생각하여 이런 부분은 모두가 공유하면 좋을 것 같습니다!
- 슬랙에 먼저 공유한 후 명세서 소셜로그인/계정 변경하기 명세서에도 반영하겠습니다

2. SignUpService 내의 변수명 및 파라미터 순서 통일
- 이미 소셜 로그인, 계정 변경하기 서비스 로직에서 oauth 플랫폼으로부터 조회해온 식별자를 authPlatformId로 사용하고 있었기 때문에 identifier 변수명을 수정하여 통일하였습니다.
- 식별자라는 변수명도 좋지만 저희 서비스에서 authPlatformId라고 사용하기로 했기 때문에 이후 코드를 보았을 때 혼란을 야기할 수 있는 부분을 최소화하면 좋겠다는 생각이 들어 수정했습니다
- 또한 파라미터의 순서가 token, authPlatform 순서로 통일되면 좋겠다고 생각하여 관련된 메서드들의 파라미터 순서도 통일했습니다
```
methodA(String token, AuthPlatform authPlatform);
methodB(String authPlatformId, AuthPlatform authPlatform);
```
- 위와 같이 authPlatform이 뒤에 오는 방식으로 통일했습니다

3. OAuthService 인터페이스 재정의
- 제가 이전에 선언했던 메서드만 존재하고 getIdentifierByToken 메서드가 정의되어 있지 않아 이를 선언하고 사용되지 않는 메서드를 삭제했습니다

4. 사용하지 않는 클래스, 메서드 삭제
- Google/Apple Service/Client 클래스에서 사용되지 않는 로직을 삭제했습니다
- IdToken을 조회해오는 필요성이 없어짐에 따라 관련 dto 레코드도 삭제했습니다

5. GoogleAuthClient getPublicKeySet 예외처리 관심사 수정
- 예외가 apple로 되어 있어 google 예외를 추가하고 반영했습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 아자아자 파이팅..~
- property 부분에서 저희가 id token을 조회해오지 않음에 따라 필요하지 않은 값들이 있는데요 .env 파일 수정도 필요하고 일단 배포가 우선인 것 같아서 이 부분은 PR을 따로 날리겠습니다! 현재 로직이 잘 되는지 테스트가 우선인 것 같아서요