### PR TITLE
[FIX] jwtAuthenticationFilter의 검증 로직 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/support/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/makers/authentication/support/security/filter/JwtAuthenticationFilter.java
@@ -2,12 +2,10 @@ package sopt.makers.authentication.support.security.filter;
 
 import static sopt.makers.authentication.support.constant.SystemConstant.WHITE_PATHS;
 
-import sopt.makers.authentication.support.constant.JwtConstant;
 import sopt.makers.authentication.support.jwt.provider.JwtAuthAccessTokenProvider;
 import sopt.makers.authentication.support.security.authentication.CustomAuthentication;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -63,11 +61,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   private static boolean isJwksRequest(HttpServletRequest request) {
-    boolean isCorrectUrl = request.getRequestURI().equals("/.well-known/jwks.json");
-    boolean isCorrectHeader =
-        Arrays.stream(JwtConstant.SERVICE_NAMES)
-            .anyMatch(request.getHeader(HttpHeaders.SERVER)::contains);
-
-    return isCorrectUrl && isCorrectHeader;
+    return request.getRequestURI().equals("/.well-known/jwks.json");
   }
 }


### PR DESCRIPTION

## Related Issue 🚀
- closed #39 

## Work Description ✏️

Jwks 요청 시 발생하는 에러를 수정했습니다. 
기존에 Header.Server를 체크하고 있었는데, 필요 없는 로직이 에러를 발생시키고 있어서 삭제했습니다. 

