### PR TITLE
[FIX/#41] JWT 필터 내 whilelist 처리 오류 해결

### DIFF
--- a/src/main/java/sopt/makers/authentication/support/code/support/failure/CommonFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/support/failure/CommonFailure.java
@@ -1,0 +1,17 @@
+package sopt.makers.authentication.support.code.support.failure;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import sopt.makers.authentication.support.code.base.*;
+
+import org.springframework.http.*;
+
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum CommonFailure implements FailureCode {
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다");
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
@@ -12,14 +12,9 @@ public final class SystemConstant {
   public static final String API_DEFAULT_PREFIX = API_PATH_PREFIX + API_VERSION;
 
   private static final String PATH_ACTUATOR = "/actuator";
-  private static final String PATH_AUTH = API_DEFAULT_PREFIX + "/auth";
+  public static final String PATH_AUTH = API_DEFAULT_PREFIX + "/auth";
   private static final String PATH_ERROR = "/error";
   private static final String PATH_TEST = "/test";
-  private static final String PATH_GET_REGISTER_SOCIAL_PLATFORM =
-      API_PATH_PREFIX + "/social/accounts/social";
-
-  public static List<String> WHITE_PATHS =
-      List.of(PATH_ACTUATOR, PATH_AUTH, PATH_GET_REGISTER_SOCIAL_PLATFORM, PATH_ERROR, PATH_TEST);
 
   public static final String PATTERN_ALL = "/**";
   public static final String PATTERN_ERROR_PATH = PATH_ERROR + PATTERN_ALL;
@@ -27,4 +22,7 @@ public final class SystemConstant {
   public static final String PATTERN_AUTH = PATH_AUTH + PATTERN_ALL;
   public static final String PATTERN_TEST = API_DEFAULT_PREFIX + PATH_TEST + PATTERN_ALL;
   public static final String PATTERN_ROOT_PATH = "/";
+
+  public static final List<String> WHITELIST_WILDCARD =
+      List.of(PATH_ERROR, PATH_ACTUATOR, PATH_AUTH, PATH_TEST);
 }

--- a/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
@@ -9,7 +9,7 @@ public final class SystemConstant {
   private static final String API_PATH_PREFIX = "/api";
   private static final String API_VERSION = "/v1";
 
-  public static final String API_DEFAULT_PREFIX = API_PATH_PREFIX + API_VERSION;
+  private static final String API_DEFAULT_PREFIX = API_PATH_PREFIX + API_VERSION;
 
   private static final String PATH_ACTUATOR = "/actuator";
   public static final String PATH_AUTH = API_DEFAULT_PREFIX + "/auth";

--- a/src/main/java/sopt/makers/authentication/support/exception/ApplicationExceptionHandler.java
+++ b/src/main/java/sopt/makers/authentication/support/exception/ApplicationExceptionHandler.java
@@ -1,9 +1,11 @@
 package sopt.makers.authentication.support.exception;
 
+import static sopt.makers.authentication.support.code.support.failure.CommonFailure.INTERNAL_SERVER_ERROR;
+
 import sopt.makers.authentication.support.common.api.BaseResponse;
 import sopt.makers.authentication.support.exception.domain.AuthException;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -12,9 +14,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class ApplicationExceptionHandler {
+  @ExceptionHandler(RuntimeException.class)
+  ResponseEntity<BaseResponse<?>> handleInternalException(final RuntimeException e) {
+    log.error(e.getMessage());
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(BaseResponse.ofFailure(INTERNAL_SERVER_ERROR));
+  }
 
   @ExceptionHandler(AuthException.class)
-  ResponseEntity<BaseResponse<?>> authFailureException(final AuthException e) {
+  ResponseEntity<BaseResponse<?>> handleAuthException(final AuthException e) {
     log.error(e.getError().getMessage());
     return ResponseEntity.status(e.getError().getStatus().value())
         .body(BaseResponse.ofFailure(e.getError()));

--- a/src/main/java/sopt/makers/authentication/support/exception/ApplicationExceptionHandler.java
+++ b/src/main/java/sopt/makers/authentication/support/exception/ApplicationExceptionHandler.java
@@ -3,7 +3,7 @@ package sopt.makers.authentication.support.exception;
 import static sopt.makers.authentication.support.code.support.failure.CommonFailure.INTERNAL_SERVER_ERROR;
 
 import sopt.makers.authentication.support.common.api.BaseResponse;
-import sopt.makers.authentication.support.exception.domain.AuthException;
+import sopt.makers.authentication.support.exception.base.*;
 
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,8 +21,8 @@ public class ApplicationExceptionHandler {
         .body(BaseResponse.ofFailure(INTERNAL_SERVER_ERROR));
   }
 
-  @ExceptionHandler(AuthException.class)
-  ResponseEntity<BaseResponse<?>> handleAuthException(final AuthException e) {
+  @ExceptionHandler(BaseException.class)
+  ResponseEntity<BaseResponse<?>> handleBusinessException(final BaseException e) {
     log.error(e.getError().getMessage());
     return ResponseEntity.status(e.getError().getStatus().value())
         .body(BaseResponse.ofFailure(e.getError()));

--- a/src/main/java/sopt/makers/authentication/support/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/makers/authentication/support/security/filter/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import sopt.makers.authentication.support.security.authentication.CustomAuthenti
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Optional;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -32,6 +33,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   protected void doFilterInternal(
       final HttpServletRequest request, final HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
+
+    if (shouldNotFilter(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
 
     String authorizationToken = getAuthorizationToken(request);
     CustomAuthentication authentication = authTokenProvider.parse(authorizationToken);
@@ -65,8 +71,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private static boolean isJwksRequest(HttpServletRequest request) {
     boolean isCorrectUrl = request.getRequestURI().equals("/.well-known/jwks.json");
     boolean isCorrectHeader =
-        Arrays.stream(JwtConstant.SERVICE_NAMES)
-            .anyMatch(request.getHeader(HttpHeaders.SERVER)::contains);
+        Optional.ofNullable(request.getHeader(HttpHeaders.SERVER))
+            .map(header -> Arrays.stream(JwtConstant.SERVICE_NAMES).anyMatch(header::contains))
+            .orElse(false);
 
     return isCorrectUrl && isCorrectHeader;
   }

--- a/src/main/java/sopt/makers/authentication/support/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/makers/authentication/support/security/filter/JwtAuthenticationFilter.java
@@ -1,14 +1,11 @@
 package sopt.makers.authentication.support.security.filter;
 
-import static sopt.makers.authentication.support.constant.SystemConstant.WHITE_PATHS;
+import static sopt.makers.authentication.support.constant.SystemConstant.WHITELIST_WILDCARD;
 
-import sopt.makers.authentication.support.constant.JwtConstant;
 import sopt.makers.authentication.support.jwt.provider.JwtAuthAccessTokenProvider;
 import sopt.makers.authentication.support.security.authentication.CustomAuthentication;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Optional;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -54,8 +51,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   private boolean isWhiteRequest(final HttpServletRequest request) {
-    String url = request.getRequestURL().toString();
-    return WHITE_PATHS.stream().anyMatch(url::contains);
+    String uri = request.getRequestURI();
+    return WHITELIST_WILDCARD.stream().anyMatch(uri::startsWith);
   }
 
   /**
@@ -70,11 +67,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private static boolean isJwksRequest(HttpServletRequest request) {
     boolean isCorrectUrl = request.getRequestURI().equals("/.well-known/jwks.json");
-    boolean isCorrectHeader =
-        Optional.ofNullable(request.getHeader(HttpHeaders.SERVER))
-            .map(header -> Arrays.stream(JwtConstant.SERVICE_NAMES).anyMatch(header::contains))
-            .orElse(false);
-
-    return isCorrectUrl && isCorrectHeader;
+    return isCorrectUrl;
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #41 

## Work Description ✏️
- 올바른 경로로 요청을 보내도 500 에러가 반환되는 문제
  - 확인해보니 jwtFilter에서 whitelist면 필더를 넘기는 구문이 없었습니다
  - 또한 리스트에 포함된 경로들이 제대로 설정되지 않는 문제가 있었어요
- 이에 따라 whitelist일 경우 jwt 검증 없이 다음 필터로 넘기는 구문을 추가하고, constant에 선언된 public list를 수정해주었습니다
- 또한 다음과 같이 규격화되지 않는 에러가 반환되고 있어 ExceptionHandler에 500 예외에 대한 처리를 추가했습니다
  - 제가 알기로 앱에서는 웹과 다르게 응답 값의 형태가 변경되면 핸들링이 어려운 것으로 알고 있습니다!  
![image](https://github.com/user-attachments/assets/97b7cb63-6721-42cc-a880-d7f028098366)
- 더하여 AuthException만 처리되고 있어 BaseException이 발생할 경우 모두 규격화된 에러가 반환되도록 수정했습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
