### PR TITLE
[FEAT/#46] 번호 인증 예외 케이스 세분화 및 테스트 코드 이슈 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: 🔑 Create Test Environment File
         run: |
-          mkdir -p src/test/resources/env
+          mkdir -p src/main/resources/env
           echo "${{ secrets.TEST_ENV_FILE }}" > src/main/resources/env/test.env
 
       - name: 🧱 Build with Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
 
       - name: 🔑 Create Key File related JWT
         run: |
-          mkdir -p ./sopt-auth-backend/src/main/resources
-          echo "${{ secrets.JWT_PRIVATE_KEY }}" > ./sopt-auth-backend/src/main/resources/jwt_private_key.pem
-          echo "${{ secrets.JWT_PUBLIC_KEY }}" > ./sopt-auth-backend/src/main/resources/jwt_public_key.pem
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.JWT_PRIVATE_KEY }}" > ./src/main/resources/jwt_private_key.pem
+          echo "${{ secrets.JWT_PUBLIC_KEY }}" > ./src/main/resources/jwt_public_key.pem
 
       - name: 🔑 Create Test Environment File
         run: |
-          mkdir -p ./sopt-auth-backend/src/main/resources/env
-          echo "${{ secrets.TEST_ENV_FILE }}" > ./sopt-auth-backend/src/main/resources/env/test.env
+          mkdir -p ./src/main/resources/env
+          echo "${{ secrets.TEST_ENV_FILE }}" > ./src/main/resources/env/test.env
 
       - name: 🧱 Build and Test with Gradle
         run: ./gradlew build --no-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
 
       - name: 🔑 Create Key File related JWT
         run: |
-          echo "${{ secrets.JWT_PRIVATE_KEY }}" > src/main/resources/jwt_private_key.pem
-          echo "${{ secrets.JWT_PUBLIC_KEY }}" > src/main/resources/jwt_public_key.pem
+          echo "${{ secrets.JWT_PRIVATE_KEY }}" > ./sopt-auth-backend/src/main/resources/jwt_private_key.pem
+          echo "${{ secrets.JWT_PUBLIC_KEY }}" > ./sopt-auth-backend/src/main/resources/jwt_public_key.pem
 
       - name: 🔑 Create Test Environment File
         run: |
           mkdir -p src/main/resources/env
-          echo "${{ secrets.TEST_ENV_FILE }}" > src/main/resources/env/test.env
+          echo "${{ secrets.TEST_ENV_FILE }}" > ./sopt-auth-backend/src/main/resources/env/test.env
 
       - name: 🧱 Build and Test with Gradle
         run: ./gradlew build --no-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
           
           echo "${{ secrets.PROPERTY_GRADLE }}" >> ./gradle.properties
 
+      - name: 🔑 Create Test Environment File
+        run: |
+          mkdir -p src/test/resources/env
+          echo "${{ secrets.TEST_ENV_FILE }}" > src/test/resources/env/test.env
+
       - name: 🧱 Build with Gradle
         run: docker build -t app-ci .
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,13 @@ jobs:
 
       - name: 🔑 Create Key File related JWT
         run: |
+          mkdir -p ./sopt-auth-backend/src/main/resources
           echo "${{ secrets.JWT_PRIVATE_KEY }}" > ./sopt-auth-backend/src/main/resources/jwt_private_key.pem
           echo "${{ secrets.JWT_PUBLIC_KEY }}" > ./sopt-auth-backend/src/main/resources/jwt_public_key.pem
 
       - name: 🔑 Create Test Environment File
         run: |
-          mkdir -p src/main/resources/env
+          mkdir -p ./sopt-auth-backend/src/main/resources/env
           echo "${{ secrets.TEST_ENV_FILE }}" > ./sopt-auth-backend/src/main/resources/env/test.env
 
       - name: 🧱 Build and Test with Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
       - name: 🔑 Create Application Property File
         run: |
           touch ./gradle.properties
-          
           echo "${{ secrets.PROPERTY_GRADLE }}" >> ./gradle.properties
 
       - name: 🔑 Create Key File related JWT
@@ -39,6 +38,10 @@ jobs:
           mkdir -p src/main/resources/env
           echo "${{ secrets.TEST_ENV_FILE }}" > src/main/resources/env/test.env
 
-      - name: 🧱 Build with Gradle
+      - name: 🧱 Build and Test with Gradle
+        run: ./gradlew build --no-daemon
+        shell: bash
+
+      - name: 🐳 Build with Gradle
         run: docker build -t app-ci .
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,15 @@ jobs:
           
           echo "${{ secrets.PROPERTY_GRADLE }}" >> ./gradle.properties
 
+      - name: 🔑 Create Key File related JWT
+        run: |
+          echo "${{ secrets.JWT_PRIVATE_KEY }}" > src/main/resources/jwt_private_key.pem
+          echo "${{ secrets.JWT_PUBLIC_KEY }}" > src/main/resources/jwt_public_key.pem
+
       - name: 🔑 Create Test Environment File
         run: |
           mkdir -p src/test/resources/env
-          echo "${{ secrets.TEST_ENV_FILE }}" > src/test/resources/env/test.env
+          echo "${{ secrets.TEST_ENV_FILE }}" > src/main/resources/env/test.env
 
       - name: 🧱 Build with Gradle
         run: docker build -t app-ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app-build
 COPY . /app-build
 
 # create .jar
-RUN echo "Build with PROFILE=${PROFILE}" && ./gradlew build -x test -Pprofile=${PROFILE} --no-daemon
+RUN echo "Build with PROFILE=${PROFILE}" && ./gradlew build -Pprofile=${PROFILE} --no-daemon
 
 # Run-Time Image Setting
 FROM openjdk:21-jdk-slim as production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,15 @@
-FROM openjdk:21-jdk-slim as builder
-
-# 기본값 : test
-ARG PROFILE=test
-
-# mkdir /app-build && cd /app-build
-WORKDIR /app-build
-
-# docker cp . gradle:app-build
-COPY . /app-build
-
-# create .jar
-RUN echo "Build with PROFILE=${PROFILE}" && ./gradlew build -Pprofile=${PROFILE} --no-daemon
-
-# Run-Time Image Setting
 FROM openjdk:21-jdk-slim as production
 
-# mkdir /app-run && cd /app-run
+# 빌드 시 전달된 PROFILE 인수를 받을 ARG 설정
+ARG PROFILE
+ENV SPRING_PROFILES_ACTIVE=${PROFILE}
+
+# 작업 디렉토리 생성 및 이동
 WORKDIR /app-run
 
-# copy .jar to Run-Time Image
-COPY --from=builder /app-build/build/libs/authentication.jar /app-run/authentication.jar
-
+# 빌드된 .jar 파일 복사
+COPY build/libs/authentication.jar /app-run/authentication.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java"]
-CMD ["-Dspring.config.additional-location=file:/app-run/", "-jar", "authentication.jar"]
+CMD ["-Dspring.config.additional-location=file:/app-run/env/application.env", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-jar", "authentication.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY build/libs/authentication.jar /app-run/authentication.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java"]
-CMD ["-Dspring.config.additional-location=file:/app-run/env/application.env", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-jar", "authentication.jar"]
+CMD ["-Dspring.config.additional-location=file:/app-run/", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-jar", "authentication.jar"]

--- a/src/main/java/sopt/makers/authentication/AuthenticationApplication.java
+++ b/src/main/java/sopt/makers/authentication/AuthenticationApplication.java
@@ -2,7 +2,6 @@ package sopt.makers.authentication;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.*;
 
 @SpringBootApplication(scanBasePackages = {"sopt.makers.authentication"})
 public class AuthenticationApplication {

--- a/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/response/AuthResponse.java
@@ -13,12 +13,10 @@ import lombok.RequiredArgsConstructor;
 public final class AuthResponse {
 
   public record VerifyResult(
-      @JsonProperty("isVerified") boolean isVerified,
-      @JsonProperty("name") String name,
-      @JsonProperty("phone") String phone) {
+      @JsonProperty("name") String name, @JsonProperty("phone") String phone) {
     public static VerifyResult from(
         VerifyPhoneVerificationUsecase.VerifyVerificationResult result) {
-      return new VerifyResult(result.isSuccess(), result.targetName(), result.targetPhone());
+      return new VerifyResult(result.targetName(), result.targetPhone());
     }
   }
 

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/auth/PhoneVerificationJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/auth/PhoneVerificationJpaRepository.java
@@ -9,8 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 interface PhoneVerificationJpaRepository extends JpaRepository<PhoneVerificationEntity, Long> {
 
-  Optional<PhoneVerificationEntity> findByPhoneAndCodeAndType(
-      String phone, String code, PhoneVerificationType type);
+  Optional<PhoneVerificationEntity> findByPhoneAndType(String phone, PhoneVerificationType type);
 
   void deleteByNameAndPhoneAndCodeAndType(
       String name, String phone, String code, PhoneVerificationType type);

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/auth/PhoneVerificationRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/auth/PhoneVerificationRetriever.java
@@ -19,10 +19,7 @@ public class PhoneVerificationRetriever {
 
   public PhoneVerificationEntity find(PhoneVerification phoneVerification) {
     return jpaRepository
-        .findByPhoneAndCodeAndType(
-            phoneVerification.getPhone(),
-            phoneVerification.getVerificationCode().getCode(),
-            phoneVerification.getVerificationType())
+        .findByPhoneAndType(phoneVerification.getPhone(), phoneVerification.getVerificationType())
         .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_PHONE_VERIFICATION));
   }
 }

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
@@ -15,6 +15,7 @@ public enum AuthFailure implements FailureCode {
   // 400
   INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다"),
   INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "ID 토큰 유효성 검사에 실패했습니다."),
+  INVALID_PHONE_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
 
   // 404
   NOT_FOUND_PHONE_VERIFICATION(HttpStatus.NOT_FOUND, "존재하지 않는 번호 인증 이력입니다."),

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/in/VerifyPhoneVerificationUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/in/VerifyPhoneVerificationUsecase.java
@@ -9,5 +9,5 @@ public interface VerifyPhoneVerificationUsecase {
   record VerifyVerificationCommand(
       String name, String phone, String code, PhoneVerificationType verificationType) {}
 
-  record VerifyVerificationResult(boolean isSuccess, String targetName, String targetPhone) {}
+  record VerifyVerificationResult(String targetName, String targetPhone) {}
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationService.java
@@ -1,6 +1,9 @@
 package sopt.makers.authentication.usecase.auth.service;
 
+import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.INVALID_PHONE_VERIFICATION_CODE;
+
 import sopt.makers.authentication.domain.auth.PhoneVerification;
+import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.PhoneVerificationRepository;
 
@@ -18,14 +21,15 @@ public class VerifyVerificationService implements VerifyPhoneVerificationUsecase
     PhoneVerification targetVerification =
         PhoneVerification.of(
             command.name(), command.phone(), command.verificationType(), command.code());
-
     PhoneVerification findVerification =
         phoneVerificationRepository.findByPhoneVerification(targetVerification);
-    boolean isVerified = targetVerification.equals(findVerification);
+    boolean isNotVerified =
+        !targetVerification.getVerificationCode().equals(findVerification.getVerificationCode());
 
-    if (isVerified) {
-      phoneVerificationRepository.deletedByPhoneVerification(findVerification);
+    if (isNotVerified) {
+      throw new AuthException(INVALID_PHONE_VERIFICATION_CODE);
     }
-    return new VerifyVerificationResult(isVerified, command.name(), command.phone());
+    phoneVerificationRepository.deletedByPhoneVerification(findVerification);
+    return new VerifyVerificationResult(command.name(), command.phone());
   }
 }

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -7,8 +7,10 @@ spring:
       - classpath:external.yaml
       - classpath:jwt.yaml
   datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password:
+    driver-class-name: ${DB_DRIVER_CLASS}
 
 management:
   endpoints:

--- a/src/main/resources/external.yaml
+++ b/src/main/resources/external.yaml
@@ -2,6 +2,7 @@ spring.config.activate.on-profile:
   - prod
   - dev
   - local
+  - test
 external:
   makers:
     playground:
@@ -30,34 +31,3 @@ external:
       client:
         id: ${GOOGLE_CLIENT_ID}
         secret: ${GOOGLE_CLIENT_SECRET}
----
-spring.config.activate.on-profile:
-  - test
-external:
-  makers:
-    playground:
-      url: test
-      token: test
-  gabia:
-    sms:
-      id: test
-      key: test
-      url: test
-      phone: test
-  oauth:
-    apple:
-      aud: test
-      sub: test
-      key:
-        id: test
-        path: test
-      team:
-        id: test
-      expiration:
-        token-expiration: 0
-    google:
-      redirect:
-        url: test
-      client:
-        id: test
-        secret: test

--- a/src/main/resources/jpa.yaml
+++ b/src/main/resources/jpa.yaml
@@ -26,3 +26,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+      database-platform: ${JPA_DATABASE_PLATFORM}
+      database: ${JPA_DATABASE}

--- a/src/main/resources/jwt.yaml
+++ b/src/main/resources/jwt.yaml
@@ -2,6 +2,7 @@ spring.config.activate.on-profile:
   - prod
   - dev
   - local
+  - test
 jwt:
   secret:
     rsa:
@@ -12,15 +13,15 @@ jwt:
       refresh-token-expiration: ${REFRESH_TOKEN_EXPIRATION_TIME}
     issuer:
       issuer-name: ${ISSUER}
----
-spring.config.activate.on-profile: test
-jwt:
-  secret:
-    rsa:
-      public-key: test
-      private-key: test
-    expiration:
-      access-token-expiration: 0
-      refresh-token-expiration: 0
-    issuer:
-      issuer-name: test
+#---
+#spring.config.activate.on-profile: test
+#jwt:
+#  secret:
+#    rsa:
+#      public-key: ${RSA_PUBLIC_KEY_PATH}
+#      private-key: ${RSA_PRIVATE_KEY_PATH}
+#    expiration:
+#      access-token-expiration: 0
+#      refresh-token-expiration: 0
+#    issuer:
+#      issuer-name: ${ISSUER}

--- a/src/test/java/sopt/makers/authentication/AuthenticationApplicationTests.java
+++ b/src/test/java/sopt/makers/authentication/AuthenticationApplicationTests.java
@@ -3,10 +3,11 @@ package sopt.makers.authentication;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 @ConfigurationPropertiesScan(basePackageClasses = AuthenticationApplication.class)
 class AuthenticationApplicationTests {
 

--- a/src/test/java/sopt/makers/authentication/application/auth/api/AuthApiControllerTest.java
+++ b/src/test/java/sopt/makers/authentication/application/auth/api/AuthApiControllerTest.java
@@ -45,7 +45,7 @@ class AuthApiControllerTest {
 
     // when
     when(verifyPhoneVerificationUsecase.verify(any(VerifyVerificationCommand.class)))
-        .thenReturn(new VerifyVerificationResult(true, "TEST", "01012345678"));
+        .thenReturn(new VerifyVerificationResult("TEST", "01012345678"));
     mockMvc
         .perform(
             post("/api/v1/auth/verify/phone")
@@ -56,7 +56,6 @@ class AuthApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.success").value("true"))
         .andExpect(jsonPath("$.message").value("번호 인증에 성공했습니다."))
-        .andExpect(jsonPath("$.data.isVerified").value("true"))
         .andExpect(jsonPath("$.data.name").value("TEST"))
         .andExpect(jsonPath("$.data.phone").value("01012345678"));
   }

--- a/src/test/java/sopt/makers/authentication/application/auth/api/AuthApiControllerTest.java
+++ b/src/test/java/sopt/makers/authentication/application/auth/api/AuthApiControllerTest.java
@@ -1,16 +1,18 @@
 package sopt.makers.authentication.application.auth.api;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase.*;
 
 import sopt.makers.authentication.support.util.CookieUtil;
 import sopt.makers.authentication.usecase.auth.port.in.AuthenticateSocialAccountUsecase;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase;
+import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase;
 import sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase;
+import sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase.VerifyVerificationCommand;
+import sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase.VerifyVerificationResult;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +24,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,11 +33,13 @@ import org.springframework.test.web.servlet.MockMvc;
     controllers = {AuthApiController.class},
     excludeAutoConfiguration = {SecurityAutoConfiguration.class})
 @ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 class AuthApiControllerTest {
   @Autowired MockMvc mockMvc;
   @MockBean VerifyPhoneVerificationUsecase verifyPhoneVerificationUsecase;
   @MockBean CreatePhoneVerificationUsecase createPhoneVerificationUsecase;
   @MockBean AuthenticateSocialAccountUsecase authenticateSocialAccountUsecase;
+  @MockBean SignUpUsecase signUpUsecase;
   @MockBean CookieUtil cookieUtil;
 
   @Test

--- a/src/test/java/sopt/makers/authentication/database/PhoneVerificationRepositoryImplTest.java
+++ b/src/test/java/sopt/makers/authentication/database/PhoneVerificationRepositoryImplTest.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 class PhoneVerificationRepositoryImplTest {
 
   @Autowired private PhoneVerificationRepository phoneVerificationRepository;

--- a/src/test/java/sopt/makers/authentication/domain/auth/PhoneVerificationTest.java
+++ b/src/test/java/sopt/makers/authentication/domain/auth/PhoneVerificationTest.java
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
+@ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 class PhoneVerificationTest {
 
   private PhoneVerification testPhoneVerification;

--- a/src/test/java/sopt/makers/authentication/jwt/JwtAccessTokenTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtAccessTokenTest.java
@@ -14,14 +14,11 @@ import java.text.ParseException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtEncoder;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.*;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
@@ -32,12 +29,9 @@ import com.nimbusds.jwt.SignedJWT;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 public class JwtAccessTokenTest {
-
-  private static final Logger log = LoggerFactory.getLogger(JwtAccessTokenTest.class);
   @Autowired private JwtAuthAccessTokenProvider jwtAuthAccessTokenProvider;
-
-  @Autowired private JwtEncoder jwtEncoder;
 
   @Autowired private JwtDecoder jwtDecoder;
 
@@ -70,7 +64,7 @@ public class JwtAccessTokenTest {
     Jwt jwt = jwtDecoder.decode(pureToken);
 
     // Then
-    assertThat(jwt.getClaims().get("iss")).isEqualTo("operation");
+    assertThat(jwt.getClaims().get("iss")).isEqualTo("authentication");
     assertThat(jwt.getClaims().get("sub")).isEqualTo("test");
   }
 

--- a/src/test/java/sopt/makers/authentication/jwt/JwtPropertyTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtPropertyTest.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 public class JwtPropertyTest {
 
   @Autowired private JwtProperty jwtProperty;

--- a/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
@@ -7,7 +7,6 @@ import static sopt.makers.authentication.support.jwt.provider.JwtTokenUtil.extra
 
 import sopt.makers.authentication.support.exception.support.TokenException;
 import sopt.makers.authentication.support.jwt.provider.JwtAuthRefreshTokenProvider;
-import sopt.makers.authentication.support.value.JwtProperty;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -22,18 +21,16 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 public class JwtRefreshTokenTest {
 
   @Autowired private JwtAuthRefreshTokenProvider jwtAuthRefreshTokenProvider;
-
   @Autowired private JwtEncoder jwtEncoder;
-
   @Autowired private JwtDecoder jwtDecoder;
-
-  @Autowired private JwtProperty jwtProperty;
 
   @Test
   @DisplayName("RefreshToken 생성")

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationServiceTest.java
@@ -29,9 +29,11 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 class CreateVerificationServiceTest {
   private static final String TEST_NAME_REGISTER_INFO = "TEST REGISTER INFO";
   private static final String TEST_NAME_USER = "TEST USER";

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/GetSocialAccountPlatformServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/GetSocialAccountPlatformServiceTest.java
@@ -25,8 +25,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
-@ActiveProfiles("local")
-@TestPropertySource(locations = {"classpath:env/local.env"})
+@ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 class GetSocialAccountPlatformServiceTest {
   private static final String PLATFORM_NAME_GOOGLE = "GOOGLE";
   private static final String PLATFORM_NAME_APPLE = "APPLE";

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/GetSocialAccountPlatformServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/GetSocialAccountPlatformServiceTest.java
@@ -63,6 +63,7 @@ class GetSocialAccountPlatformServiceTest {
   void 주어진_Command에_대해_의도한_결과값을_반환한다(
       // given
       GetSocialAccountUsecase.GetSocialAccountPlatformCommand givenCommand, String expectedResult) {
+
     // when
     GetSocialAccountUsecase.SocialAccountPlatformInfo result =
         getSocialAccountPlatformService.getSocialAccountPlatform(givenCommand);

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationServiceTest.java
@@ -45,7 +45,7 @@ class VerifyVerificationServiceTest {
     VerifyVerificationResult result = verifyService.verify(givenCommand);
 
     // then
-    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.targetPhone()).isEqualTo(givenVerifyPhone);
     assertThatThrownBy(() -> phoneVerificationRepository.findByPhoneVerification(givenVerification))
         .isInstanceOf(AuthException.class)
         .hasMessageContaining(AuthFailure.NOT_FOUND_PHONE_VERIFICATION.getMessage());

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationServiceTest.java
@@ -15,9 +15,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
 class VerifyVerificationServiceTest {
 
   @Autowired private PhoneVerificationRepository phoneVerificationRepository;


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #46

## Work Description ✏️
- 번호 인증에 대한 예외를 세분화하였습니다
  - 기존: 인증코드, 번호 인증 유형, 전화번호 3개 중 하나라도 일치하지 않으면 404 not found 예외를 전달
  - 변경: 번호 인증 유형과 전화번호로 생성된 인증 내역이 없는 경우에 404 not found 예외를 전달하고, 인증 내역은 존재하나 인증코드가 일치하지 않는 경우에 대해서는 400 예외를 반환
- jwt pem 파일로 인해 테스트 코드가 돌아가지 않는 문제를 해결했습니다
  - 로컬에서 동작하는 것까지 확인하여 ci yml을 수정해 github actions에서도 테스트 코드를 통과해야지만 동작하도록 스크립트를 변경해주었습니다
  - 관련 값을 노션에도 업데이트 해두었습니다! 로컬에서 테스트를 돌려보고 싶다면 test.env 파일을 생성해주세요
 
## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 어떤 리뷰든 환영 합니다~