### PR TITLE
[FIX/#54] 애플로그인 JWSVerifier 구현체를 RSASAVerifier로 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
@@ -1,6 +1,5 @@
 package sopt.makers.authentication.external.oauth;
 
-import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
 import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_ISSUER;
 
 import sopt.makers.authentication.external.oauth.client.AppleAuthClient;
@@ -8,7 +7,6 @@ import sopt.makers.authentication.support.code.domain.failure.AuthFailure;
 import sopt.makers.authentication.support.code.support.failure.TokenFailure;
 import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.support.exception.support.TokenException;
-import sopt.makers.authentication.support.util.*;
 import sopt.makers.authentication.support.value.AppleOAuthProperty;
 
 import java.text.ParseException;
@@ -19,7 +17,7 @@ import org.springframework.stereotype.Component;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
-import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -61,7 +59,7 @@ public class AppleAuthService implements OAuthService {
   private void verifyAppleIdTokenJwt(final SignedJWT jwt, JWK jwk) throws ParseException {
     try {
       JWTClaimsSet jwtClaimsSet = jwt.getJWTClaimsSet();
-      JWSVerifier verifier = new ECDSAVerifier(jwk.toECKey());
+      JWSVerifier verifier = new RSASSAVerifier(jwk.toRSAKey());
 
       boolean isVerifiedSignature = jwt.verify(verifier);
       boolean isCorrectIssuer = jwtClaimsSet.getIssuer().equals(APPLE_ISSUER);


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #54 

## Work Description ✏️
- 애플로그인 JWSVerifier 구현체를 RSASAVerifier로 수정하여 `class com.nimbusds.jose.jwk.RSAKey cannot be cast to class com.nimbusds.jose.jwk.ECKey` 오류를 해결했습니다! 이전에 구글 로그인에서도 생겼던 오류인데 둘다 RSA로 매칭해야하는데, 잘못 매칭하고 있어서 발생한 문제였습니다 🥹

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
