### PR TITLE
[FIX/#56] Apple 로그인 findMatchJWK 로직 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
@@ -49,9 +49,11 @@ public class AppleAuthService implements OAuthService {
 
   private JWK findMatchJWK(final SignedJWT jwt) {
     JWKSet loadedJWKSet = appleAuthClient.getPublicKeySet();
-    String keyID = jwt.getHeader().getKeyID();
+    String kid = jwt.getHeader().getKeyID();
+    String alg = jwt.getHeader().getAlgorithm().getName();
+
     return loadedJWKSet.getKeys().stream()
-        .filter(jwk -> jwk.getKeyID().equals(keyID))
+        .filter(jwk -> jwk.getKeyID().equals(kid) && jwk.getAlgorithm().getName().equals(alg))
         .findFirst()
         .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET));
   }

--- a/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
@@ -40,8 +40,7 @@ public class AppleAuthService implements OAuthService {
       JWK targetJwk = findMatchJWK(signedJWT);
 
       verifyAppleIdTokenJwt(signedJWT, targetJwk);
-      String identifier = signedJWT.getJWTClaimsSet().getSubject();
-      return identifier;
+      return signedJWT.getJWTClaimsSet().getSubject();
     } catch (ParseException e) {
       throw new TokenException(TokenFailure.TOKEN_PARSE_FAILED);
     }

--- a/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
@@ -46,10 +46,10 @@ public class GoogleAuthService implements OAuthService {
 
   private JWK findMatchJWK(final SignedJWT jwt) {
     JWKSet loadedJWKSet = googleAuthClient.getPublicKeySet();
-    String keyID = jwt.getHeader().getKeyID();
+    String kid = jwt.getHeader().getKeyID();
 
     return loadedJWKSet.getKeys().stream()
-        .filter(jwk -> jwk.getKeyID().equals(keyID))
+        .filter(jwk -> jwk.getKeyID().equals(kid))
         .findFirst()
         .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET));
   }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #56

## Work Description ✏️
- **AS-IS: 구글과 마찬가지로 kid가 일치하는 key를 조회하여 반환**
```
private JWK findMatchJWK(final SignedJWT jwt) {
    JWKSet loadedJWKSet = appleAuthClient.getPublicKeySet();
    String keyID = jwt.getHeader().getKeyID();
    return loadedJWKSet.getKeys().stream()
        .filter(jwk -> jwk.getKeyID().equals(keyID))
        .findFirst()
        .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET));
  }
```

- **TO-BE: kid와 alg가 일치하는 key를 조회하여 반환**
```
private JWK findMatchJWK(final SignedJWT jwt) {
    JWKSet loadedJWKSet = appleAuthClient.getPublicKeySet();
    String kid = jwt.getHeader().getKeyID();
    String alg = jwt.getHeader().getAlgorithm().getName();

    return loadedJWKSet.getKeys().stream()
        .filter(jwk -> jwk.getKeyID().equals(kid) && jwk.getAlgorithm().getName().equals(alg))
        .findFirst()
        .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET));
  }
```

- `TO-BE`로 변경하였고, 애플로그인의 대략적인 플로우는 [해당 블로그](https://velog.io/@komment/Spring-Boot-OAuth-2.0-JWT%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%86%8C%EC%85%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84-2-%EC%95%A0%ED%94%8C%ED%8E%B8)를 참고했습니다!
![image](https://github.com/user-attachments/assets/50e59c29-ad99-4b6f-b38b-56bd30e4c0b4)

- 또한 구글로그인에서 keyID 필드를 kid로 이름을 변경해주었습니다. JWK에서 사용되는 명칭이 통상적으로 `alg(알고리즘)`, `kid(KeyID)`이기 때문에 저희 프로젝트에서도 개념을 일치시켜가면 더 좋을 것 같아 리팩토링 해보았습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 따끔한 피드백은 항상 환영합니다 !