### PR TITLE
[FIX/#48] SignUpService - 유저 기수 정보 저장하도록 수정 

### DIFF
--- a/src/main/java/sopt/makers/authentication/database/rdb/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/entity/UserEntity.java
@@ -12,8 +12,6 @@ import java.time.LocalDate;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 
-import org.hibernate.annotations.ColumnDefault;
-
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -37,10 +35,6 @@ public class UserEntity extends BaseEntity {
   @NotNull
   @Enumerated(EnumType.STRING)
   AuthPlatform authPlatformType;
-
-  @NotNull
-  @ColumnDefault(value = "false")
-  Boolean isActive;
 
   private UserEntity(
       String name,

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
@@ -6,7 +6,7 @@ import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
 
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,9 +24,10 @@ public class UserRepositoryImpl implements UserRepository {
 
   @Transactional
   @Override
-  public void save(User user) {
+  public User save(User user) {
     UserEntity userEntity = UserEntity.fromDomain(user);
     userRegister.save(userEntity);
+    return userEntity.toDomain();
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryJpaRepository.java
@@ -1,0 +1,7 @@
+package sopt.makers.authentication.database.rdb.repository.user.activity;
+
+import sopt.makers.authentication.database.rdb.entity.UserActivityHistoryEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface UserActivityHistoryJpaRepository extends JpaRepository<UserActivityHistoryEntity, Long> {}

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRegister.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRegister.java
@@ -1,0 +1,20 @@
+package sopt.makers.authentication.database.rdb.repository.user.activity;
+
+import sopt.makers.authentication.database.rdb.entity.UserActivityHistoryEntity;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class UserActivityHistoryRegister {
+
+  private final UserActivityHistoryJpaRepository userActivityHistoryJpaRepository;
+
+  public void save(UserActivityHistoryEntity userActivityHistoryEntity) {
+    userActivityHistoryJpaRepository.save(userActivityHistoryEntity);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRegister.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRegister.java
@@ -3,12 +3,10 @@ package sopt.makers.authentication.database.rdb.repository.user.activity;
 import sopt.makers.authentication.database.rdb.entity.UserActivityHistoryEntity;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
-@Transactional
 @RequiredArgsConstructor
 public class UserActivityHistoryRegister {
 

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRepositoryImpl.java
@@ -6,15 +6,18 @@ import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 @Repository
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserActivityHistoryRepositoryImpl implements UserActivityHistoryRepository {
 
   private final UserActivityHistoryRegister userActivityHistoryRegister;
 
+  @Transactional
   @Override
   public void save(User user, Activity activity) {
     UserActivityHistoryEntity userActivityHistoryEntity =

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRepositoryImpl.java
@@ -1,0 +1,24 @@
+package sopt.makers.authentication.database.rdb.repository.user.activity;
+
+import sopt.makers.authentication.database.rdb.entity.UserActivityHistoryEntity;
+import sopt.makers.authentication.domain.user.Activity;
+import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserActivityHistoryRepositoryImpl implements UserActivityHistoryRepository {
+
+  private final UserActivityHistoryRegister userActivityHistoryRegister;
+
+  @Override
+  public void save(User user, Activity activity) {
+    UserActivityHistoryEntity userActivityHistoryEntity =
+        UserActivityHistoryEntity.fromDomain(user, activity);
+    userActivityHistoryRegister.save(userActivityHistoryEntity);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
@@ -9,7 +9,7 @@ public interface UserRepository {
 
   User findByPhone(String phone);
 
-  void save(User user);
+  User save(User user);
 
   void update(User user, SocialAccount socialAccount);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
@@ -2,12 +2,14 @@ package sopt.makers.authentication.usecase.auth.service;
 
 import sopt.makers.authentication.domain.auth.AuthPlatform;
 import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
+import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
 
 import org.springframework.stereotype.Service;
@@ -22,6 +24,7 @@ public class SignUpService implements SignUpUsecase {
 
   private final UserRepository userRepository;
   private final UserRegisterInfoRepository userRegisterInfoRepository;
+  private final UserActivityHistoryRepository userActivityHistoryRepository;
 
   @Transactional
   @Override
@@ -30,11 +33,13 @@ public class SignUpService implements SignUpUsecase {
         oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     UserRegisterInfo registerInfo = userRegisterInfoRepository.findByPhone(command.phone());
 
-    SocialAccount socialAccount = createSocialAccount(authPlatformId, command.authPlatform());
+    SocialAccount socialAccount = createSocialAccount("1234", command.authPlatform());
     Profile profile = createProfile(registerInfo);
+    Activity activity = createActivity(registerInfo);
     User newUser = User.createNewUser(socialAccount, profile);
 
-    userRepository.save(newUser);
+    User savedUser = userRepository.save(newUser);
+    userActivityHistoryRepository.save(savedUser, activity);
     userRegisterInfoRepository.delete(registerInfo);
   }
 
@@ -51,5 +56,9 @@ public class SignUpService implements SignUpUsecase {
         registerInfo.getEmail(),
         registerInfo.getPhone(),
         registerInfo.getBirthday());
+  }
+
+  private Activity createActivity(UserRegisterInfo registerInfo) {
+    return Activity.of(registerInfo.getGeneration(), null, registerInfo.getPart());
   }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
@@ -33,7 +33,7 @@ public class SignUpService implements SignUpUsecase {
         oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     UserRegisterInfo registerInfo = userRegisterInfoRepository.findByPhone(command.phone());
 
-    SocialAccount socialAccount = createSocialAccount("1234", command.authPlatform());
+    SocialAccount socialAccount = createSocialAccount(authPlatformId, command.authPlatform());
     Profile profile = createProfile(registerInfo);
     Activity activity = createActivity(registerInfo);
     User newUser = User.createNewUser(socialAccount, profile);

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserActivityHistoryRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserActivityHistoryRepository.java
@@ -1,0 +1,8 @@
+package sopt.makers.authentication.usecase.user.port.out;
+
+import sopt.makers.authentication.domain.user.Activity;
+import sopt.makers.authentication.domain.user.User;
+
+public interface UserActivityHistoryRepository {
+  void save(User user, Activity activity);
+}

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
@@ -1,0 +1,88 @@
+package sopt.makers.authentication.usecase.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import sopt.makers.authentication.domain.auth.AuthPlatform;
+import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Activity;
+import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.domain.user.Profile;
+import sopt.makers.authentication.domain.user.Role;
+import sopt.makers.authentication.domain.user.Team;
+import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.domain.user.UserRegisterInfo;
+import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase.SignUpCommand;
+import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
+import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
+import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
+import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+@TestPropertySource(locations = {"classpath:env/test.env"})
+@ExtendWith(MockitoExtension.class)
+class SignUpServiceTest {
+
+  @InjectMocks private SignUpService signUpService;
+  @Mock private OAuthAuthenticator oAuthAuthenticator;
+  @Mock private UserRegisterInfoRepository userRegisterInfoRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private UserActivityHistoryRepository userActivityHistoryRepository;
+  @Mock private UserRegisterInfo userRegisterInfo;
+
+  private final String TEST_TOKEN = "dummy-token";
+  private final String TEST_PHONE = "01012345678";
+  private final Long TEST_USER_ID = 42L;
+
+  @BeforeEach
+  void setUpMocks() {
+    SocialAccount socialAccount = SocialAccount.of("oauth-123", AuthPlatform.GOOGLE);
+    Profile profile = Profile.of("테스터", "tester@sopt.org", TEST_PHONE, LocalDate.of(2000, 1, 1));
+    User mockedUser = User.createNewUser(socialAccount, profile);
+    Activity mockedActivity = Activity.of(1, Team.MAKERS, Part.SERVER, Role.MEMBER);
+
+    ReflectionTestUtils.setField(mockedUser, "id", TEST_USER_ID);
+
+    given(oAuthAuthenticator.getIdentifier(TEST_TOKEN, AuthPlatform.GOOGLE))
+        .willReturn("oauth-123");
+    given(userRegisterInfoRepository.findByPhone(TEST_PHONE)).willReturn(userRegisterInfo);
+    given(userRepository.save(any(User.class))).willReturn(mockedUser);
+  }
+
+  @Test
+  void 회원가입시_정상적으로_유저와_기수정보가_저장된다() {
+    // given
+    SignUpCommand command = new SignUpCommand("테스터", TEST_PHONE, TEST_TOKEN, AuthPlatform.GOOGLE);
+
+    // when
+    signUpService.signUp(command);
+
+    // then
+    ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+    ArgumentCaptor<Activity> activityCaptor = ArgumentCaptor.forClass(Activity.class);
+
+    verify(userRepository).save(any(User.class));
+    verify(userActivityHistoryRepository).save(userCaptor.capture(), activityCaptor.capture());
+
+    User capturedUser = userCaptor.getValue();
+    Activity capturedActivity = activityCaptor.getValue();
+
+    assertThat(capturedUser.getId()).isEqualTo(TEST_USER_ID);
+    assertThat(capturedActivity).isNotNull();
+  }
+}

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
@@ -8,10 +8,7 @@ import static org.mockito.Mockito.verify;
 import sopt.makers.authentication.domain.auth.AuthPlatform;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.user.Activity;
-import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Profile;
-import sopt.makers.authentication.domain.user.Role;
-import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase.SignUpCommand;
@@ -49,12 +46,13 @@ class SignUpServiceTest {
   private final String TEST_PHONE = "01012345678";
   private final Long TEST_USER_ID = 42L;
 
+  private final int ACTIVITY_GENERATION = 35;
+
   @BeforeEach
   void setUpMocks() {
     SocialAccount socialAccount = SocialAccount.of("oauth-123", AuthPlatform.GOOGLE);
     Profile profile = Profile.of("테스터", "tester@sopt.org", TEST_PHONE, LocalDate.of(2000, 1, 1));
     User mockedUser = User.createNewUser(socialAccount, profile);
-    Activity mockedActivity = Activity.of(1, Team.MAKERS, Part.SERVER, Role.MEMBER);
 
     ReflectionTestUtils.setField(mockedUser, "id", TEST_USER_ID);
 
@@ -62,6 +60,7 @@ class SignUpServiceTest {
         .willReturn("oauth-123");
     given(userRegisterInfoRepository.findByPhone(TEST_PHONE)).willReturn(userRegisterInfo);
     given(userRepository.save(any(User.class))).willReturn(mockedUser);
+    given(userRegisterInfo.getGeneration()).willReturn(ACTIVITY_GENERATION);
   }
 
   @Test
@@ -83,6 +82,6 @@ class SignUpServiceTest {
     Activity capturedActivity = activityCaptor.getValue();
 
     assertThat(capturedUser.getId()).isEqualTo(TEST_USER_ID);
-    assertThat(capturedActivity).isNotNull();
+    assertThat(capturedActivity.generation()).isEqualTo(ACTIVITY_GENERATION);
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #48 

## Work Description ✏️
- 회원가입 로직을 수정했습니다.
   - `TO-BE  회원가입시, `유저 기수 정보`(UserActivityHistory)`도 함께 저장되도록 

<br/>

- 아래 부분에서 고민이 좀 있었는데요! 

`UserActivityHistory` 저장 시 `User` 객체도 함께 저장되어야 하는데, 이때 전달되는 `User` 도메인이 실제 저장된 `User`의 id를 가지고 있어야 해서 아래 2가지 방안을 고민하다가 2안으로 구현했습니다!
           
☑️ 1안)
> `User` 도메인에 `setId()` 또는 `assignId() `같은 메서드를 만들어서, 저장된 ID를 주입함

☑️ 2안) 
`userRepository.save(user)` 호출 후, ID가 할당된 `UserEntity`를 다시 `User` 도메인 객체로 매핑해서 반환

첫번째 방식의 경우 User 도메인 객체의 id 필드에서 final 키워드를 제거해야 해야해서, 불변성을 지키지 못하는 것 같아 2안 방식으로 구현했습니다!


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 테스트코드도 한 번 짜보기는 했는데,,, 많이 짜보진 않아서,, 어떤 피드백도 대환영입니다..!
- 로컬에서 잘 돌아가는 거 확인했습니다~!
- 머지 직전에 Dev DB에 isActive 컬럼 삭제할게요!!
