### PR TITLE
[FIX/#43] 전화번호 인증 예외케이스 세분화 처리

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/event/PhoneVerificationEventListener.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/event/PhoneVerificationEventListener.java
@@ -14,17 +14,12 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class PhoneVerificationEventListener {
-
-  private static final String FORMAT_VERIFICATION_MESSAGE = "[SOPT makers]\n인증번호 [%s]를 입력해주세요.";
-
   private final MessageSendPort messageSendPort;
 
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handlePhoneVerificationCreated(PhoneVerificationCreatedEvent event) {
-    String content = String.format(FORMAT_VERIFICATION_MESSAGE, event.code());
-
-    Message message = Message.sms(event.phone(), content);
+    Message message = Message.sms(event.phone(), event.content());
 
     messageSendPort.sendMessage(message);
   }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationJpaRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 interface PhoneVerificationJpaRepository extends JpaRepository<PhoneVerificationEntity, Long> {
 
-  Optional<PhoneVerificationEntity> findByPhoneAndType(String phone, PhoneVerificationType type);
+  Optional<PhoneVerificationEntity> findTopByPhoneAndTypeOrderByCreatedAtDesc(
+      String phone, PhoneVerificationType type);
 
   void deleteByNameAndPhoneAndCodeAndType(
       String name, String phone, String code, PhoneVerificationType type);

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationRepositoryImpl.java
@@ -33,7 +33,7 @@ public class PhoneVerificationRepositoryImpl implements PhoneVerificationReposit
 
   @Transactional
   @Override
-  public void deletedByPhoneVerification(PhoneVerification phoneVerification) {
+  public void deleteByPhoneVerification(PhoneVerification phoneVerification) {
     remover.remove(phoneVerification);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationRetriever.java
@@ -17,7 +17,8 @@ public class PhoneVerificationRetriever {
 
   public PhoneVerificationEntity find(PhoneVerification phoneVerification) {
     return jpaRepository
-        .findByPhoneAndType(phoneVerification.getPhone(), phoneVerification.getVerificationType())
+        .findTopByPhoneAndTypeOrderByCreatedAtDesc(
+            phoneVerification.getPhone(), phoneVerification.getVerificationType())
         .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_PHONE_VERIFICATION));
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserJpaRepository.java
@@ -13,4 +13,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
       AuthPlatform authPlatformType, String authPlatformId);
 
   Optional<UserEntity> findByPhone(String phone);
+
+  boolean existsByPhone(String phone);
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
@@ -42,4 +42,9 @@ public class UserRepositoryImpl implements UserRepository {
     UserEntity userEntity = UserEntity.fromDomain(updatedUser);
     userRegister.save(userEntity);
   }
+
+  @Override
+  public boolean existsByPhone(String phone) {
+    return userRetriever.existsByPhone(phone);
+  }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
@@ -1,7 +1,7 @@
 package sopt.makers.authentication.database.rdb.repository.user;
 
 import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT;
-import static sopt.makers.authentication.support.code.domain.failure.UserFailure.NOT_FOUND_PHONE;
+import static sopt.makers.authentication.support.code.domain.failure.UserFailure.NOT_FOUND_USER;
 
 import sopt.makers.authentication.database.rdb.entity.UserEntity;
 import sopt.makers.authentication.domain.auth.SocialAccount;
@@ -29,7 +29,7 @@ public class UserRetriever {
 
   public User findByPhone(String phone) {
     UserEntity userEntity =
-        userJpaRepository.findByPhone(phone).orElseThrow(() -> new UserException(NOT_FOUND_PHONE));
+        userJpaRepository.findByPhone(phone).orElseThrow(() -> new UserException(NOT_FOUND_USER));
     return userEntity.toDomain();
   }
 

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
@@ -32,4 +32,8 @@ public class UserRetriever {
         userJpaRepository.findByPhone(phone).orElseThrow(() -> new UserException(NOT_FOUND_PHONE));
     return userEntity.toDomain();
   }
+
+  public boolean existsByPhone(String phone) {
+    return userJpaRepository.existsByPhone(phone);
+  }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/register/UserRegisterInfoRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/register/UserRegisterInfoRepositoryImpl.java
@@ -4,6 +4,8 @@ import sopt.makers.authentication.database.rdb.entity.UserRegisterInfoEntity;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
 
+import java.util.*;
+
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,15 +20,15 @@ public class UserRegisterInfoRepositoryImpl implements UserRegisterInfoRepositor
   private final UserRegisterInfoRemover remover;
 
   @Override
-  public UserRegisterInfo findByPhone(String phone) {
-    UserRegisterInfoEntity targetRegisterInfo = retriever.findByPhone(phone);
-    return targetRegisterInfo.toDomain();
+  public Optional<UserRegisterInfo> findByPhone(String phone) {
+    return retriever.findByPhone(phone).map(UserRegisterInfoEntity::toDomain);
   }
 
   @Transactional
   @Override
   public void delete(UserRegisterInfo userRegisterInfo) {
-    UserRegisterInfoEntity registerInfoEntity = retriever.findByPhone(userRegisterInfo.getPhone());
-    remover.remove(registerInfoEntity);
+    Optional<UserRegisterInfoEntity> registerInfoEntity =
+        retriever.findByPhone(userRegisterInfo.getPhone());
+    registerInfoEntity.ifPresent(remover::remove);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/register/UserRegisterInfoRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/register/UserRegisterInfoRepositoryImpl.java
@@ -4,7 +4,7 @@ import sopt.makers.authentication.database.rdb.entity.UserRegisterInfoEntity;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
 
-import java.util.*;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/register/UserRegisterInfoRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/register/UserRegisterInfoRetriever.java
@@ -2,7 +2,7 @@ package sopt.makers.authentication.database.rdb.repository.user.register;
 
 import sopt.makers.authentication.database.rdb.entity.UserRegisterInfoEntity;
 
-import java.util.*;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/register/UserRegisterInfoRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/register/UserRegisterInfoRetriever.java
@@ -1,8 +1,8 @@
 package sopt.makers.authentication.database.rdb.repository.user.register;
 
 import sopt.makers.authentication.database.rdb.entity.UserRegisterInfoEntity;
-import sopt.makers.authentication.support.code.domain.failure.UserFailure;
-import sopt.makers.authentication.support.exception.domain.UserException;
+
+import java.util.*;
 
 import org.springframework.stereotype.Component;
 
@@ -13,9 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class UserRegisterInfoRetriever {
   private final UserRegisterInfoJpaRepository jpaRepository;
 
-  public UserRegisterInfoEntity findByPhone(String phone) {
-    return jpaRepository
-        .findByPhone(phone)
-        .orElseThrow(() -> new UserException(UserFailure.NOT_FOUND_REGISTER_INFO));
+  public Optional<UserRegisterInfoEntity> findByPhone(String phone) {
+    return jpaRepository.findByPhone(phone);
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/PhoneVerificationCreatedEvent.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/PhoneVerificationCreatedEvent.java
@@ -2,4 +2,4 @@ package sopt.makers.authentication.domain.auth;
 
 import sopt.makers.authentication.domain.message.MessageType;
 
-public record PhoneVerificationCreatedEvent(String phone, String code, MessageType type) {}
+public record PhoneVerificationCreatedEvent(String phone, String content, MessageType type) {}

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
@@ -16,6 +16,7 @@ public enum AuthFailure implements FailureCode {
   INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다"),
   INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "ID 토큰 유효성 검사에 실패했습니다."),
   INVALID_PHONE_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
+  ALREADY_REGISTER_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 가입된 전화번호입니다."),
 
   // 401
   INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "API 키가 유효하지 않습니다"),
@@ -24,7 +25,7 @@ public enum AuthFailure implements FailureCode {
   NOT_FOUND_PHONE_VERIFICATION(HttpStatus.NOT_FOUND, "존재하지 않는 번호 인증 이력입니다."),
   NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 계정 정보와 일치하는 회원이 없습니다"),
   NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET(HttpStatus.NOT_FOUND, "유효한 Public Key Set를 찾을 수 없습니다."),
-  ;
+  NOT_FOUND_REGISTER_INFO(HttpStatus.NOT_FOUND, "가입 정보를 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/UserFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/UserFailure.java
@@ -18,9 +18,7 @@ public enum UserFailure implements FailureCode {
   // 404
   NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다"),
   NOT_FOUND_PART(HttpStatus.NOT_FOUND, "존재하지 않는 파트입니다"),
-  NOT_FOUND_PHONE(HttpStatus.NOT_FOUND, "존재하지 않는 핸드폰 번호입니다"),
-  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-  NOT_FOUND_REGISTER_INFO(HttpStatus.NOT_FOUND, "존재하지 않는 가입 대상 정보입니다.");
+  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
   private final HttpStatus status;
   private final String message;
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/PhoneVerificationRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/PhoneVerificationRepository.java
@@ -8,5 +8,5 @@ public interface PhoneVerificationRepository {
 
   PhoneVerification findByPhoneVerification(PhoneVerification phoneVerification);
 
-  void deletedByPhoneVerification(PhoneVerification phoneVerification);
+  void deleteByPhoneVerification(PhoneVerification phoneVerification);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository {
   User save(User user);
 
   void update(User user, SocialAccount socialAccount);
+
+  boolean existsByPhone(String phone);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
@@ -34,14 +34,12 @@ public class CreateVerificationService implements CreatePhoneVerificationUsecase
   @Transactional
   public PhoneVerification create(CreateVerificationCommand command) {
     PhoneVerification phoneVerification = createPhoneVerificationByCommand(command);
-
     PhoneVerification savedPhoneVerification = verificationRepository.create(phoneVerification);
+    String content = convertCodeToMessage(savedPhoneVerification.getVerificationCode().getCode());
 
     eventPublisher.publishEvent(
         new PhoneVerificationCreatedEvent(
-            savedPhoneVerification.getPhone(),
-            savedPhoneVerification.getVerificationCode().getCode(),
-            MessageType.SMS));
+            savedPhoneVerification.getPhone(), content, MessageType.SMS));
     return savedPhoneVerification;
   }
 

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
@@ -1,14 +1,22 @@
 package sopt.makers.authentication.usecase.auth.service;
 
+import static sopt.makers.authentication.domain.auth.PhoneVerificationType.REGISTER;
+import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.ALREADY_REGISTER_PHONE_NUMBER;
+import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.NOT_FOUND_REGISTER_INFO;
+
 import sopt.makers.authentication.domain.auth.PhoneVerification;
+import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.domain.message.Message;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
+import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.PhoneVerificationRepository;
 import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
 import sopt.makers.authentication.usecase.message.port.out.MessageSendPort;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
+
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
@@ -40,17 +48,29 @@ public class CreateVerificationService implements CreatePhoneVerificationUsecase
 
   private PhoneVerification createPhoneVerificationByCommand(CreateVerificationCommand command) {
     return switch (command.verificationType()) {
-      case REGISTER -> {
-        UserRegisterInfo registerInfo = userRegisterInfoRepository.findByPhone(command.phone());
-        yield PhoneVerification.create(
-            registerInfo.getName(), registerInfo.getPhone(), command.verificationType());
-      }
-      case CHANGE, SEARCH -> {
-        User user = userRepository.findByPhone(command.phone());
-        yield PhoneVerification.create(
-            user.getProfile().name(), user.getProfile().phone(), command.verificationType());
-      }
+      case REGISTER -> handleRegister(command.phone());
+      case CHANGE, SEARCH -> handleChangeOrSearch(command.phone(), command.verificationType());
     };
+  }
+
+  private PhoneVerification handleRegister(String phone) {
+    Optional<UserRegisterInfo> targetRegisterInfo = userRegisterInfoRepository.findByPhone(phone);
+
+    if (targetRegisterInfo.isPresent()) {
+      UserRegisterInfo registerInfo = targetRegisterInfo.get();
+      return PhoneVerification.create(registerInfo.getName(), registerInfo.getPhone(), REGISTER);
+    }
+
+    boolean existUser = userRepository.existsByPhone(phone);
+    if (existUser) {
+      throw new AuthException(ALREADY_REGISTER_PHONE_NUMBER);
+    }
+    throw new AuthException(NOT_FOUND_REGISTER_INFO);
+  }
+
+  private PhoneVerification handleChangeOrSearch(String phone, PhoneVerificationType type) {
+    User user = userRepository.findByPhone(phone);
+    return PhoneVerification.create(user.getProfile().name(), user.getProfile().phone(), type);
   }
 
   private String convertCodeToMessage(String code) {

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
@@ -19,6 +19,7 @@ import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoReposito
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.*;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,6 +35,7 @@ public class CreateVerificationService implements CreatePhoneVerificationUsecase
   private final MessageSendPort messageSendPort;
 
   @Override
+  @Transactional
   public PhoneVerification create(CreateVerificationCommand command) {
     PhoneVerification phoneVerification = createPhoneVerificationByCommand(command);
 

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
@@ -8,15 +8,12 @@ import sopt.makers.authentication.domain.auth.PhoneVerification;
 import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.domain.message.Message;
 import sopt.makers.authentication.domain.user.User;
-import sopt.makers.authentication.domain.user.UserRegisterInfo;
 import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.PhoneVerificationRepository;
 import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
 import sopt.makers.authentication.usecase.message.port.out.MessageSendPort;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
-
-import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.*;
@@ -56,18 +53,17 @@ public class CreateVerificationService implements CreatePhoneVerificationUsecase
   }
 
   private PhoneVerification handleRegister(String phone) {
-    Optional<UserRegisterInfo> targetRegisterInfo = userRegisterInfoRepository.findByPhone(phone);
-
-    if (targetRegisterInfo.isPresent()) {
-      UserRegisterInfo registerInfo = targetRegisterInfo.get();
-      return PhoneVerification.create(registerInfo.getName(), registerInfo.getPhone(), REGISTER);
-    }
-
-    boolean existUser = userRepository.existsByPhone(phone);
-    if (existUser) {
-      throw new AuthException(ALREADY_REGISTER_PHONE_NUMBER);
-    }
-    throw new AuthException(NOT_FOUND_REGISTER_INFO);
+    return userRegisterInfoRepository
+        .findByPhone(phone)
+        .map(info -> PhoneVerification.create(info.getName(), info.getPhone(), REGISTER))
+        .orElseThrow(
+            () -> {
+              boolean existUser = userRepository.existsByPhone(phone);
+              if (existUser) {
+                return new AuthException(ALREADY_REGISTER_PHONE_NUMBER);
+              }
+              return new AuthException(NOT_FOUND_REGISTER_INFO);
+            });
   }
 
   private PhoneVerification handleChangeOrSearch(String phone, PhoneVerificationType type) {

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
@@ -1,16 +1,21 @@
 package sopt.makers.authentication.usecase.auth.service;
 
+import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.NOT_FOUND_REGISTER_INFO;
+
 import sopt.makers.authentication.domain.auth.AuthPlatform;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
+import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
+
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,14 +36,20 @@ public class SignUpService implements SignUpUsecase {
   public void signUp(SignUpCommand command) {
     String authPlatformId =
         oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
-    UserRegisterInfo registerInfo = userRegisterInfoRepository.findByPhone(command.phone());
+    Optional<UserRegisterInfo> targetRegisterInfo =
+        userRegisterInfoRepository.findByPhone(command.phone());
 
+    if (targetRegisterInfo.isEmpty()) {
+      throw new AuthException(NOT_FOUND_REGISTER_INFO);
+    }
+
+    UserRegisterInfo registerInfo = targetRegisterInfo.get();
     SocialAccount socialAccount = createSocialAccount(authPlatformId, command.authPlatform());
     Profile profile = createProfile(registerInfo);
     Activity activity = createActivity(registerInfo);
     User newUser = User.createNewUser(socialAccount, profile);
-
     User savedUser = userRepository.save(newUser);
+
     userActivityHistoryRepository.save(savedUser, activity);
     userRegisterInfoRepository.delete(registerInfo);
   }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
@@ -15,8 +15,6 @@ import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,22 +34,19 @@ public class SignUpService implements SignUpUsecase {
   public void signUp(SignUpCommand command) {
     String authPlatformId =
         oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
-    Optional<UserRegisterInfo> targetRegisterInfo =
-        userRegisterInfoRepository.findByPhone(command.phone());
+    UserRegisterInfo targetRegisterInfo =
+        userRegisterInfoRepository
+            .findByPhone(command.phone())
+            .orElseThrow(() -> new AuthException(NOT_FOUND_REGISTER_INFO));
 
-    if (targetRegisterInfo.isEmpty()) {
-      throw new AuthException(NOT_FOUND_REGISTER_INFO);
-    }
-
-    UserRegisterInfo registerInfo = targetRegisterInfo.get();
     SocialAccount socialAccount = createSocialAccount(authPlatformId, command.authPlatform());
-    Profile profile = createProfile(registerInfo);
-    Activity activity = createActivity(registerInfo);
+    Profile profile = createProfile(targetRegisterInfo);
+    Activity activity = createActivity(targetRegisterInfo);
     User newUser = User.createNewUser(socialAccount, profile);
     User savedUser = userRepository.save(newUser);
 
     userActivityHistoryRepository.save(savedUser, activity);
-    userRegisterInfoRepository.delete(registerInfo);
+    userRegisterInfoRepository.delete(targetRegisterInfo);
   }
 
   private SocialAccount createSocialAccount(String authPlatformId, AuthPlatform authPlatform) {

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationService.java
@@ -29,7 +29,7 @@ public class VerifyVerificationService implements VerifyPhoneVerificationUsecase
     if (isNotVerified) {
       throw new AuthException(INVALID_PHONE_VERIFICATION_CODE);
     }
-    phoneVerificationRepository.deletedByPhoneVerification(findVerification);
+    phoneVerificationRepository.deleteByPhoneVerification(findVerification);
     return new VerifyVerificationResult(command.name(), command.phone());
   }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRegisterInfoRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRegisterInfoRepository.java
@@ -2,9 +2,11 @@ package sopt.makers.authentication.usecase.user.port.out;
 
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 
+import java.util.*;
+
 public interface UserRegisterInfoRepository {
 
-  UserRegisterInfo findByPhone(String phone);
+  Optional<UserRegisterInfo> findByPhone(String phone);
 
   void delete(UserRegisterInfo userRegisterInfo);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRegisterInfoRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRegisterInfoRepository.java
@@ -2,7 +2,7 @@ package sopt.makers.authentication.usecase.user.port.out;
 
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 
-import java.util.*;
+import java.util.Optional;
 
 public interface UserRegisterInfoRepository {
 

--- a/src/test/java/sopt/makers/authentication/database/PhoneVerificationRepositoryImplTest.java
+++ b/src/test/java/sopt/makers/authentication/database/PhoneVerificationRepositoryImplTest.java
@@ -33,7 +33,7 @@ class PhoneVerificationRepositoryImplTest {
   void flushTestPhoneVerification() {
     PhoneVerification testVerification =
         PhoneVerification.of(null, "01012345678", PhoneVerificationType.REGISTER, "123456");
-    phoneVerificationRepository.deletedByPhoneVerification(testVerification);
+    phoneVerificationRepository.deleteByPhoneVerification(testVerification);
   }
 
   @Test

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationServiceTest.java
@@ -1,11 +1,13 @@
 package sopt.makers.authentication.usecase.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.ALREADY_REGISTER_PHONE_NUMBER;
 import static sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase.CreateVerificationCommand;
 
 import sopt.makers.authentication.domain.auth.PhoneVerification;
@@ -14,6 +16,7 @@ import sopt.makers.authentication.domain.message.Message;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
+import sopt.makers.authentication.support.exception.domain.*;
 import sopt.makers.authentication.usecase.auth.port.out.PhoneVerificationRepository;
 import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
 import sopt.makers.authentication.usecase.message.port.out.MessageSendPort;
@@ -81,6 +84,23 @@ class CreateVerificationServiceTest {
     // then
     assertThat(resultPhoneVerification.getName()).isEqualTo(TEST_NAME_REGISTER_INFO);
     assertThat(resultPhoneVerification.getPhone()).isEqualTo(TEST_PHONE_REGISTER_INFO);
+  }
+
+  @Test
+  @DisplayName("인증 유형이 REGISTER 일 경우, 이미 회원인 사람은 예외가 발생해야 합니다")
+  void createVerificationRegisterForExistUser() {
+    // given
+    PhoneVerificationType givenType = PhoneVerificationType.REGISTER;
+    CreateVerificationCommand givenCommand =
+        new CreateVerificationCommand(null, TEST_PHONE_REGISTER_INFO, givenType);
+    when(userRegisterInfoRepository.findByPhone(TEST_PHONE_REGISTER_INFO))
+        .thenReturn(Optional.empty());
+    when(userRepository.existsByPhone(TEST_PHONE_REGISTER_INFO)).thenReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> usecase.create(givenCommand))
+        .isInstanceOf(AuthException.class)
+        .hasMessageContaining(ALREADY_REGISTER_PHONE_NUMBER.getMessage());
   }
 
   @Test

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationServiceTest.java
@@ -20,6 +20,7 @@ import sopt.makers.authentication.usecase.message.port.out.MessageSendPort;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,7 +58,8 @@ class CreateVerificationServiceTest {
     when(mockedUserRegisterInfo.getPhone()).thenReturn("01087654321");
 
     when(userRepository.findByPhone(anyString())).thenReturn(mockedUser);
-    when(userRegisterInfoRepository.findByPhone(anyString())).thenReturn(mockedUserRegisterInfo);
+    when(userRegisterInfoRepository.findByPhone(anyString()))
+        .thenReturn(Optional.of(mockedUserRegisterInfo));
     doNothing().when(sendPort).sendMessage(isA(Message.class));
 
     usecase =

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
@@ -18,6 +18,7 @@ import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepos
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,8 @@ class SignUpServiceTest {
 
     given(oAuthAuthenticator.getIdentifier(TEST_TOKEN, AuthPlatform.GOOGLE))
         .willReturn("oauth-123");
-    given(userRegisterInfoRepository.findByPhone(TEST_PHONE)).willReturn(userRegisterInfo);
+    given(userRegisterInfoRepository.findByPhone(TEST_PHONE))
+        .willReturn(Optional.of(userRegisterInfo));
     given(userRepository.save(any(User.class))).willReturn(mockedUser);
     given(userRegisterInfo.getGeneration()).willReturn(ACTIVITY_GENERATION);
   }

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationServiceTest.java
@@ -33,7 +33,7 @@ class VerifyVerificationServiceTest {
   }
 
   @Test
-  void verifySuccessTest() {
+  void 번호인증시_정상적으로_인증이_완료된다() {
     // given
     String givenVerifyPhone = "01012345678";
     PhoneVerificationType givenVerifyType = PhoneVerificationType.REGISTER;
@@ -51,5 +51,24 @@ class VerifyVerificationServiceTest {
     assertThatThrownBy(() -> phoneVerificationRepository.findByPhoneVerification(givenVerification))
         .isInstanceOf(AuthException.class)
         .hasMessageContaining(AuthFailure.NOT_FOUND_PHONE_VERIFICATION.getMessage());
+  }
+
+  @Test
+  void 여러개의_인증이력이_존재하더라도_최신인증이력으로_검증한다() {
+    // given
+    PhoneVerification latestVerification =
+        PhoneVerification.of(null, "01012345678", PhoneVerificationType.REGISTER, "123457");
+    phoneVerificationRepository.create(latestVerification);
+    String givenVerifyPhone = "01012345678";
+    PhoneVerificationType givenVerifyType = PhoneVerificationType.REGISTER;
+    String givenCode = "123457";
+    VerifyVerificationCommand givenCommand =
+        new VerifyVerificationCommand(null, givenVerifyPhone, givenCode, givenVerifyType);
+
+    // when
+    VerifyVerificationResult result = verifyService.verify(givenCommand);
+
+    // then
+    assertThat(result.targetPhone()).isEqualTo(givenVerifyPhone);
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #43

## Work Description ✏️
- "회원가입" 목적으로 문자 인증을 요청할 때에 대한 예외를 세분화했습니다
  - case1. 이미 회원가입을 하여 user 테이블에 존재하는 경우
  - case2. SOPT 회원이 아닌데 회원가입 요청을 하는 경우
- 회원의 전화번호 인증이 여러 개일 경우 엔티티가 매칭되지 않는 문제를 해결했습니다
  - redis를 도입하지 않는 방향으로 일단 구현하자고 회의때 결정나서 가장 최근에 생성된 이력 1개만 불러오도록 repository 단에서 처리해주었습니다!

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 인증이 완료되면 해당 인증은 지워지지만 이전에 생성되었으나 사용자가 인증을 마치지 않아서 테이블에 남아있는 레코드들은 삭제되지 않는 상황입니다.
- 스케줄러로 주기적으로 지워줄지, 아니면 redis를 도입해서 ttl로 만료시간을 설정할지 논의를 조금 더 해보면 좋을 것 같습니다
- 특히 동시적으로 들어오는 요청 흐름에 대해서는 Redis 분산 락을 활용하면 좋을 것 같은데요 두 분의 의견이 궁금합니다 ㅎㅎ (회원가입 같은 경우에도 적용 가능할 것 같네요~!)