### PR TITLE
[FEAT/#65] 문자 인증 비동기 처리

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/event/PhoneVerificationEventListener.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/event/PhoneVerificationEventListener.java
@@ -1,0 +1,31 @@
+package sopt.makers.authentication.application.auth.event;
+
+import sopt.makers.authentication.domain.auth.PhoneVerificationCreatedEvent;
+import sopt.makers.authentication.domain.message.Message;
+import sopt.makers.authentication.usecase.message.port.out.MessageSendPort;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PhoneVerificationEventListener {
+
+  private static final String FORMAT_VERIFICATION_MESSAGE = "[SOPT makers]\n인증번호 [%s]를 입력해주세요.";
+
+  private final MessageSendPort messageSendPort;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handlePhoneVerificationCreated(PhoneVerificationCreatedEvent event) {
+    String content = String.format(FORMAT_VERIFICATION_MESSAGE, event.code());
+
+    Message message = Message.sms(event.phone(), content);
+
+    messageSendPort.sendMessage(message);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/domain/auth/PhoneVerificationCreatedEvent.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/PhoneVerificationCreatedEvent.java
@@ -1,0 +1,5 @@
+package sopt.makers.authentication.domain.auth;
+
+import sopt.makers.authentication.domain.message.MessageType;
+
+public record PhoneVerificationCreatedEvent(String phone, String code, MessageType type) {}

--- a/src/main/java/sopt/makers/authentication/external/gabia/MessageSender.java
+++ b/src/main/java/sopt/makers/authentication/external/gabia/MessageSender.java
@@ -3,6 +3,7 @@ package sopt.makers.authentication.external.gabia;
 import sopt.makers.authentication.domain.message.Message;
 import sopt.makers.authentication.usecase.message.port.out.MessageSendPort;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ public class MessageSender implements MessageSendPort {
   private final GabiaClient gabiaClient;
 
   @Override
+  @Async
   public void sendMessage(Message message) {
     switch (message.getType()) {
       case SMS -> gabiaClient.sendSmsMessage(message.getReceiver(), message.getContent());

--- a/src/main/java/sopt/makers/authentication/external/gabia/MessageSender.java
+++ b/src/main/java/sopt/makers/authentication/external/gabia/MessageSender.java
@@ -3,7 +3,6 @@ package sopt.makers.authentication.external.gabia;
 import sopt.makers.authentication.domain.message.Message;
 import sopt.makers.authentication.usecase.message.port.out.MessageSendPort;
 
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -15,7 +14,6 @@ public class MessageSender implements MessageSendPort {
   private final GabiaClient gabiaClient;
 
   @Override
-  @Async
   public void sendMessage(Message message) {
     switch (message.getType()) {
       case SMS -> gabiaClient.sendSmsMessage(message.getReceiver(), message.getContent());

--- a/src/main/java/sopt/makers/authentication/support/config/AsyncConfig.java
+++ b/src/main/java/sopt/makers/authentication/support/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package sopt.makers.authentication.support.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {}

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
@@ -1,15 +1,16 @@
 package sopt.makers.authentication.usecase.auth.service;
 
 import sopt.makers.authentication.domain.auth.PhoneVerification;
-import sopt.makers.authentication.domain.message.Message;
+import sopt.makers.authentication.domain.auth.PhoneVerificationCreatedEvent;
+import sopt.makers.authentication.domain.message.MessageType;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 import sopt.makers.authentication.usecase.auth.port.in.CreatePhoneVerificationUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.PhoneVerificationRepository;
 import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
-import sopt.makers.authentication.usecase.message.port.out.MessageSendPort;
 import sopt.makers.authentication.usecase.user.port.out.UserRegisterInfoRepository;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -18,24 +19,23 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CreateVerificationService implements CreatePhoneVerificationUsecase {
 
-  private static final String FORMAT_VERIFICATION_MESSAGE = "[SOPT makers]\n인증번호 [%s]를 입력해주세요.";
-
   private final UserRepository userRepository;
   private final UserRegisterInfoRepository userRegisterInfoRepository;
   private final PhoneVerificationRepository verificationRepository;
-  private final MessageSendPort messageSendPort;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Override
   public PhoneVerification create(CreateVerificationCommand command) {
     PhoneVerification phoneVerification = createPhoneVerificationByCommand(command);
 
-    Message verificationMessage =
-        Message.sms(
-            command.phone(),
-            convertCodeToMessage(phoneVerification.getVerificationCode().getCode()));
+    PhoneVerification savedPhoneVerification = verificationRepository.create(phoneVerification);
 
-    messageSendPort.sendMessage(verificationMessage);
-    return verificationRepository.create(phoneVerification);
+    eventPublisher.publishEvent(
+        new PhoneVerificationCreatedEvent(
+            savedPhoneVerification.getPhone(),
+            savedPhoneVerification.getVerificationCode().getCode(),
+            MessageType.SMS));
+    return savedPhoneVerification;
   }
 
   private PhoneVerification createPhoneVerificationByCommand(CreateVerificationCommand command) {
@@ -51,9 +51,5 @@ public class CreateVerificationService implements CreatePhoneVerificationUsecase
             user.getProfile().name(), user.getProfile().phone(), command.verificationType());
       }
     };
-  }
-
-  private String convertCodeToMessage(String code) {
-    return String.format(FORMAT_VERIFICATION_MESSAGE, code);
   }
 }

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
@@ -44,6 +45,7 @@ class CreateVerificationServiceTest {
   @Mock UserRegisterInfoRepository userRegisterInfoRepository;
   @Mock MessageSendPort sendPort;
   @Autowired PhoneVerificationRepository verificationRepository;
+  @Mock ApplicationEventPublisher eventPublisher;
 
   @InjectMocks CreateVerificationService usecase;
 
@@ -62,7 +64,7 @@ class CreateVerificationServiceTest {
 
     usecase =
         new CreateVerificationService(
-            userRepository, userRegisterInfoRepository, verificationRepository, sendPort);
+            userRepository, userRegisterInfoRepository, verificationRepository, eventPublisher);
   }
 
   @Test


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #65 

## Work Description ✏️
- 가비아 API 요청 시 응답 대기 시간이 길어질 경우 timeout 발생 가능성 존재
- 문자 전송 로직에 `@TransactionalEventListener + @Async`  적용하여 응답을 기다리지 않고 비동기로 처리

## PR Point 📸
- 비동기 처리로 인해 가비아 응답 실패 여부와 관계없이 API 응답은 항상 `성공(200)`으로 반환되는 구조입니다. 실제 문자 전송 실패 시 어떻게 처리하는 것이 좋을지 고민해볼 필요가 있을 것 같습니다. 현재는 오류 처리를 하지 않지만, 실패 이력을 저장하거나, 알림 시스템과 연동하는 등의 방법도 고려해볼 수 있을 것 같습니다. 지금과 같은 방식으로 문제를 해결하는 게 괜찮을지, 아니면 다른 방향이 좋을지 의견이 궁금합니다!
- `@TransactionalEventListener + @Async `조합을 통해 문자 발송 로직을 트랜잭션과 분리했습니다.