### PR TITLE
[FEAT/#67] Activity 도메인에 id 추가

### DIFF
--- a/src/main/java/sopt/makers/authentication/database/rdb/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/entity/UserActivityHistoryEntity.java
@@ -89,6 +89,6 @@ public class UserActivityHistoryEntity {
   }
 
   public Activity toDomain() {
-    return Activity.ofWithId(id, generation, team, part, role);
+    return Activity.of(id, generation, team, part, role);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/entity/UserActivityHistoryEntity.java
@@ -23,6 +23,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -36,6 +37,7 @@ import lombok.NoArgsConstructor;
 public class UserActivityHistoryEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Setter(value = PROTECTED)
   private Long id;
 
   @NotNull
@@ -72,15 +74,21 @@ public class UserActivityHistoryEntity {
 
   public static UserActivityHistoryEntity fromDomain(final User user, final Activity activity) {
     UserEntity userEntity = UserEntity.fromDomain(user);
-    return new UserActivityHistoryEntity(
-        userEntity,
-        activity.generation(),
-        activity.team().orElse(null),
-        activity.part().orElse(null),
-        activity.role());
+    UserActivityHistoryEntity userActivityHistoryEntity =
+        new UserActivityHistoryEntity(
+            userEntity,
+            activity.getGeneration(),
+            activity.optionalTeam().orElse(null),
+            activity.optionalPart().orElse(null),
+            activity.getRole());
+
+    if (activity.getId() != null) {
+      userActivityHistoryEntity.setId(activity.getId());
+    }
+    return userActivityHistoryEntity;
   }
 
   public Activity toDomain() {
-    return Activity.of(generation, team, part, role);
+    return Activity.ofWithId(id, generation, team, part, role);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/entity/UserActivityHistoryEntity.java
@@ -79,7 +79,7 @@ public class UserActivityHistoryEntity {
             userEntity,
             activity.getGeneration(),
             activity.optionalTeam().orElse(null),
-            activity.optionalPart().orElse(null),
+            activity.getPart(),
             activity.getRole());
 
     if (activity.getId() != null) {

--- a/src/main/java/sopt/makers/authentication/domain/user/Activity.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Activity.java
@@ -32,7 +32,7 @@ public class Activity {
     return new Activity(null, generation, team, part, role);
   }
 
-  public static Activity ofWithId(
+  public static Activity of(
       Long id, int generation, final Team team, final Part part, final Role role) {
     return new Activity(id, generation, team, part, role);
   }

--- a/src/main/java/sopt/makers/authentication/domain/user/Activity.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Activity.java
@@ -41,10 +41,6 @@ public class Activity {
     return Optional.ofNullable(team);
   }
 
-  public Optional<Part> optionalPart() {
-    return Optional.ofNullable(part);
-  }
-
   public void validateActivityContentsEmpty() {
     boolean isActivityContentsEmpty = this.role.isPartRequired() && this.part == null;
 

--- a/src/main/java/sopt/makers/authentication/domain/user/Activity.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Activity.java
@@ -6,22 +6,47 @@ import sopt.makers.authentication.support.exception.domain.UserException;
 
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
-public record Activity(
-    int generation, Optional<Team> team, Optional<Part> part, @NotNull Role role) {
+@Getter
+public class Activity {
+  private Long id;
+  private final int generation;
+  private final Team team;
+  private final Part part;
+  private final Role role;
+
+  private Activity(Long id, int generation, Team team, Part part, Role role) {
+    this.id = id;
+    this.generation = generation;
+    this.team = team;
+    this.part = part;
+    this.role = role;
+  }
 
   public static Activity of(int generation, final Team team, final Part part) {
-    return new Activity(
-        generation, Optional.ofNullable(team), Optional.ofNullable(part), Role.MEMBER);
+    return new Activity(null, generation, team, part, Role.MEMBER);
   }
 
   public static Activity of(int generation, final Team team, final Part part, final Role role) {
-    return new Activity(generation, Optional.ofNullable(team), Optional.ofNullable(part), role);
+    return new Activity(null, generation, team, part, role);
+  }
+
+  public static Activity ofWithId(
+      Long id, int generation, final Team team, final Part part, final Role role) {
+    return new Activity(id, generation, team, part, role);
+  }
+
+  public Optional<Team> optionalTeam() {
+    return Optional.ofNullable(team);
+  }
+
+  public Optional<Part> optionalPart() {
+    return Optional.ofNullable(part);
   }
 
   public void validateActivityContentsEmpty() {
-    boolean isActivityContentsEmpty = this.role.isPartRequired() && this.part.isEmpty();
+    boolean isActivityContentsEmpty = this.role.isPartRequired() && this.part == null;
 
     if (isActivityContentsEmpty) {
       throw new UserException(ROLE_REQUIRES_PART);

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -31,7 +31,7 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
     User user =
         userRepository.findBySocialAccount(
             SocialAccount.of(authPlatformId, command.authPlatform()));
-    List<Role> roles = List.of(user.getActivities().getLastActivity().role());
+    List<Role> roles = List.of(user.getActivities().getLastActivity().getRole());
     CustomAuthentication customAuthentication = new CustomAuthentication(user.getId(), roles);
     String accessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
     String refreshToken = jwtAuthRefreshTokenProvider.generate(accessToken);

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
@@ -82,6 +82,6 @@ class SignUpServiceTest {
     Activity capturedActivity = activityCaptor.getValue();
 
     assertThat(capturedUser.getId()).isEqualTo(TEST_USER_ID);
-    assertThat(capturedActivity.generation()).isEqualTo(ACTIVITY_GENERATION);
+    assertThat(capturedActivity.getGeneration()).isEqualTo(ACTIVITY_GENERATION);
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #67 

## Work Description ✏️
- `Activity`에 id 필드를 추가했습니다. 
- `Activity`를 `record` -> `class`로 변경했습니다. 기존에는 `Activity` 도메인을 `record`로 구현하고 있었지만, 활동을 저장하거나 조회하는 과정에서 유연한 값 주입이 필요하다고 판단해 `class`로 변경했습니다. 

## PR Point 📸
- 지금은 Activity에 id를 추가했지만, 꼭 이렇게 id가 필요한 구조인지 확신이 들지는 않아서 다시 record로 바꾸는 것도 고민해보면 좋을 것 같습니다. 팀원분들 생각도 궁금합니다