### PR TITLE
[FEAT/#69] 모니터링 설정 구축

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.retry:spring-retry")
 
+	implementation("io.micrometer:micrometer-registry-prometheus")
+
 	implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonCoreVersion}")
 
 	implementation ("com.squareup.okhttp3:okhttp:${okHttpVersion}")

--- a/src/main/java/sopt/makers/authentication/support/config/SecurityConfig.java
+++ b/src/main/java/sopt/makers/authentication/support/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package sopt.makers.authentication.support.config;
 
-import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_ACTUATOR;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_AUTH;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_ERROR_PATH;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_TEST;
@@ -86,8 +85,6 @@ public class SecurityConfig {
                 .requestMatchers(new AntPathRequestMatcher(PATTERN_TEST))
                 .permitAll()
                 .requestMatchers(new AntPathRequestMatcher(PATTERN_ERROR_PATH))
-                .permitAll()
-                .requestMatchers(new AntPathRequestMatcher(PATTERN_ACTUATOR))
                 .permitAll()
                 .anyRequest()
                 .authenticated());

--- a/src/main/java/sopt/makers/authentication/support/config/SecurityConfig.java
+++ b/src/main/java/sopt/makers/authentication/support/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package sopt.makers.authentication.support.config;
 
+import static sopt.makers.authentication.support.constant.SystemConstant.INTERNAL_SERVICE;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_ALL;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_AUTH;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_ERROR_PATH;
@@ -86,7 +87,7 @@ public class SecurityConfig {
           for (String endpoint : securedEndpoints) {
             authorize
                 .requestMatchers(new AntPathRequestMatcher(endpoint + PATTERN_ALL))
-                .hasRole("INTERNAL_SERVICE");
+                .hasRole(INTERNAL_SERVICE);
           }
 
           authorize.anyRequest().authenticated();

--- a/src/main/java/sopt/makers/authentication/support/config/SecurityConfig.java
+++ b/src/main/java/sopt/makers/authentication/support/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package sopt.makers.authentication.support.config;
 
+import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_ALL;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_AUTH;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_ERROR_PATH;
 import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN_TEST;
@@ -7,6 +8,9 @@ import static sopt.makers.authentication.support.constant.SystemConstant.PATTERN
 import sopt.makers.authentication.support.security.filter.ApiKeyAuthenticationFilter;
 import sopt.makers.authentication.support.security.filter.AuthenticationExceptionFilter;
 import sopt.makers.authentication.support.security.filter.JwtAuthenticationFilter;
+import sopt.makers.authentication.support.value.SecurityProperty;
+
+import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +34,7 @@ public class SecurityConfig {
   private final ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
   private final AuthenticationExceptionFilter authenticationExceptionFilter;
+  private final SecurityProperty securityProperty;
 
   @Bean
   public static PasswordEncoder passwordEncoder() {
@@ -46,19 +51,8 @@ public class SecurityConfig {
   }
 
   @Bean
-  @Profile("dev")
+  @Profile({"dev", "prod"})
   public SecurityFilterChain filterChainDev(HttpSecurity http) throws Exception {
-    setDefaultHttp(http);
-    http.authorizeHttpRequests(
-        authorizeHttpRequests ->
-            authorizeHttpRequests.requestMatchers(new AntPathRequestMatcher("/v3/**")).permitAll());
-    setSecuredHttp(http);
-    return http.build();
-  }
-
-  @Bean
-  @Profile("prod")
-  public SecurityFilterChain filterChainProd(HttpSecurity http) throws Exception {
     setDefaultHttp(http);
     setSecuredHttp(http);
     return http.build();
@@ -77,16 +71,25 @@ public class SecurityConfig {
   }
 
   private void setSecuredHttp(HttpSecurity http) throws Exception {
+    List<String> securedEndpoints = securityProperty.api().securedEndpoints();
+
     http.authorizeHttpRequests(
-        authorizeHttpRequests ->
-            authorizeHttpRequests
-                .requestMatchers(new AntPathRequestMatcher(PATTERN_AUTH))
-                .permitAll()
-                .requestMatchers(new AntPathRequestMatcher(PATTERN_TEST))
-                .permitAll()
-                .requestMatchers(new AntPathRequestMatcher(PATTERN_ERROR_PATH))
-                .permitAll()
-                .anyRequest()
-                .authenticated());
+        authorize -> {
+          authorize
+              .requestMatchers(new AntPathRequestMatcher(PATTERN_AUTH))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(PATTERN_TEST))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(PATTERN_ERROR_PATH))
+              .permitAll();
+
+          for (String endpoint : securedEndpoints) {
+            authorize
+                .requestMatchers(new AntPathRequestMatcher(endpoint + PATTERN_ALL))
+                .hasRole("INTERNAL_SERVICE");
+          }
+
+          authorize.anyRequest().authenticated();
+        });
   }
 }

--- a/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
@@ -21,6 +21,10 @@ public final class SystemConstant {
   public static final String PATTERN_ROOT_PATH = "/";
 
   public static final List<String> WHITELIST_WILDCARD = List.of(PATH_ERROR, PATH_AUTH, PATH_TEST);
+
   public static final String API_KEY_HEADER = "X-Api-Key";
   public static final String SERVICE_NAME_HEADER = "X-Service-Name";
+
+  public static final String ROLE = "ROLE_";
+  public static final String INTERNAL_SERVICE = "INTERNAL_SERVICE";
 }

--- a/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
@@ -10,19 +10,15 @@ public final class SystemConstant {
   private static final String API_VERSION = "/v1";
 
   private static final String API_DEFAULT_PREFIX = API_PATH_PREFIX + API_VERSION;
-
-  private static final String PATH_ACTUATOR = "/actuator";
   public static final String PATH_AUTH = API_DEFAULT_PREFIX + "/auth";
   private static final String PATH_ERROR = "/error";
   private static final String PATH_TEST = "/test";
-
   public static final String PATTERN_ALL = "/**";
+
   public static final String PATTERN_ERROR_PATH = PATH_ERROR + PATTERN_ALL;
-  public static final String PATTERN_ACTUATOR = PATH_ACTUATOR + PATTERN_ALL;
   public static final String PATTERN_AUTH = PATH_AUTH + PATTERN_ALL;
   public static final String PATTERN_TEST = API_DEFAULT_PREFIX + PATH_TEST + PATTERN_ALL;
   public static final String PATTERN_ROOT_PATH = "/";
 
-  public static final List<String> WHITELIST_WILDCARD =
-      List.of(PATH_ERROR, PATH_ACTUATOR, PATH_AUTH, PATH_TEST);
+  public static final List<String> WHITELIST_WILDCARD = List.of(PATH_ERROR, PATH_AUTH, PATH_TEST);
 }

--- a/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/SystemConstant.java
@@ -21,4 +21,6 @@ public final class SystemConstant {
   public static final String PATTERN_ROOT_PATH = "/";
 
   public static final List<String> WHITELIST_WILDCARD = List.of(PATH_ERROR, PATH_AUTH, PATH_TEST);
+  public static final String API_KEY_HEADER = "X-Api-Key";
+  public static final String SERVICE_NAME_HEADER = "X-Service-Name";
 }

--- a/src/main/java/sopt/makers/authentication/support/security/authentication/ApiKeyAuthentication.java
+++ b/src/main/java/sopt/makers/authentication/support/security/authentication/ApiKeyAuthentication.java
@@ -1,25 +1,19 @@
 package sopt.makers.authentication.support.security.authentication;
 
-import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-public class ApiKeyAuthentication implements Authentication {
-
+public class ApiKeyAuthentication extends AbstractAuthenticationToken {
   private final String apiKey;
-  private final String product;
-  private boolean authenticated = true;
+  private final String serviceName;
 
-  public ApiKeyAuthentication(String apiKey, String product) {
+  public ApiKeyAuthentication(String apiKey, String serviceName) {
+    super(List.of(new SimpleGrantedAuthority("ROLE_INTERNAL_SERVICE")));
     this.apiKey = apiKey;
-    this.product = product;
-  }
-
-  @Override
-  public Collection<? extends GrantedAuthority> getAuthorities() {
-    return Collections.emptyList();
+    this.serviceName = serviceName;
+    super.setAuthenticated(true);
   }
 
   @Override
@@ -28,27 +22,7 @@ public class ApiKeyAuthentication implements Authentication {
   }
 
   @Override
-  public Object getDetails() {
-    return null;
-  }
-
-  @Override
   public Object getPrincipal() {
-    return apiKey;
-  }
-
-  @Override
-  public boolean isAuthenticated() {
-    return authenticated;
-  }
-
-  @Override
-  public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
-    this.authenticated = isAuthenticated;
-  }
-
-  @Override
-  public String getName() {
-    return product != null ? product : "Unknown";
+    return serviceName;
   }
 }

--- a/src/main/java/sopt/makers/authentication/support/security/authentication/ApiKeyAuthentication.java
+++ b/src/main/java/sopt/makers/authentication/support/security/authentication/ApiKeyAuthentication.java
@@ -1,5 +1,8 @@
 package sopt.makers.authentication.support.security.authentication;
 
+import static sopt.makers.authentication.support.constant.SystemConstant.INTERNAL_SERVICE;
+import static sopt.makers.authentication.support.constant.SystemConstant.ROLE;
+
 import java.util.List;
 
 import org.springframework.security.authentication.AbstractAuthenticationToken;
@@ -10,7 +13,7 @@ public class ApiKeyAuthentication extends AbstractAuthenticationToken {
   private final String serviceName;
 
   public ApiKeyAuthentication(String apiKey, String serviceName) {
-    super(List.of(new SimpleGrantedAuthority("ROLE_INTERNAL_SERVICE")));
+    super(List.of(new SimpleGrantedAuthority(ROLE + INTERNAL_SERVICE)));
     this.apiKey = apiKey;
     this.serviceName = serviceName;
     super.setAuthenticated(true);

--- a/src/main/java/sopt/makers/authentication/support/security/filter/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/sopt/makers/authentication/support/security/filter/ApiKeyAuthenticationFilter.java
@@ -23,8 +23,8 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
-  private static final String API_KEY_HEADER = "X-API-KEY";
-  private static final String SERVICE_NAME_HEADER = "X-SERVICE-NAME";
+  private static final String API_KEY_HEADER = "X-Api-Key";
+  private static final String SERVICE_NAME_HEADER = "X-Service-Name";
 
   private final SecurityProperty securityProperty;
 

--- a/src/main/java/sopt/makers/authentication/support/security/filter/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/sopt/makers/authentication/support/security/filter/ApiKeyAuthenticationFilter.java
@@ -7,7 +7,6 @@ import sopt.makers.authentication.support.security.authentication.ApiKeyAuthenti
 import sopt.makers.authentication.support.value.SecurityProperty;
 
 import java.io.IOException;
-import java.util.List;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -25,32 +24,47 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
   private static final String API_KEY_HEADER = "x-api-key";
-  private static final String PRODUCT = "product";
+  private static final String SERVICE_NAME_HEADER = "x-service-name";
+
   private final SecurityProperty securityProperty;
 
   @Override
   protected void doFilterInternal(
-      @NonNull final HttpServletRequest request,
-      @NonNull final HttpServletResponse response,
-      @NonNull final FilterChain filterChain)
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain)
       throws ServletException, IOException {
-    String requestUri = request.getRequestURI();
-    List<String> securedEndpoints = securityProperty.api().securedEndpoints();
 
-    for (String endpoint : securedEndpoints) {
-      if (requestUri.startsWith(endpoint)) {
-        String apiKey = request.getHeader(API_KEY_HEADER);
-        String product = request.getHeader(PRODUCT);
-        boolean isApiKeyInvalid = apiKey == null || !apiKey.equals(securityProperty.api().key());
-
-        if (isApiKeyInvalid) {
-          throw new AuthException(INVALID_API_KEY);
-        }
-        SecurityContextHolder.getContext()
-            .setAuthentication(new ApiKeyAuthentication(apiKey, product));
-        break;
-      }
+    String uri = request.getRequestURI();
+    if (isSecuredEndpoint(uri)) {
+      handleApiKeyAuthentication(request);
     }
+
     filterChain.doFilter(request, response);
+  }
+
+  private boolean isSecuredEndpoint(String uri) {
+    return securityProperty.api().securedEndpoints().stream().anyMatch(uri::startsWith);
+  }
+
+  private void handleApiKeyAuthentication(HttpServletRequest request) {
+    String apiKey = request.getHeader(API_KEY_HEADER);
+    String serviceName = request.getHeader(SERVICE_NAME_HEADER);
+
+    validateApiKey(apiKey, serviceName);
+
+    SecurityContextHolder.getContext()
+        .setAuthentication(new ApiKeyAuthentication(apiKey, serviceName));
+  }
+
+  private void validateApiKey(String apiKey, String serviceName) {
+    if (apiKey == null || serviceName == null) {
+      throw new AuthException(INVALID_API_KEY);
+    }
+
+    String expectedKey = securityProperty.api().keys().get(serviceName);
+    if (!apiKey.equals(expectedKey)) {
+      throw new AuthException(INVALID_API_KEY);
+    }
   }
 }

--- a/src/main/java/sopt/makers/authentication/support/security/filter/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/sopt/makers/authentication/support/security/filter/ApiKeyAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package sopt.makers.authentication.support.security.filter;
 
 import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.INVALID_API_KEY;
+import static sopt.makers.authentication.support.constant.SystemConstant.API_KEY_HEADER;
+import static sopt.makers.authentication.support.constant.SystemConstant.SERVICE_NAME_HEADER;
 
 import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.support.security.authentication.ApiKeyAuthentication;
@@ -23,8 +25,6 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
-  private static final String API_KEY_HEADER = "X-Api-Key";
-  private static final String SERVICE_NAME_HEADER = "X-Service-Name";
 
   private final SecurityProperty securityProperty;
 

--- a/src/main/java/sopt/makers/authentication/support/security/filter/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/sopt/makers/authentication/support/security/filter/ApiKeyAuthenticationFilter.java
@@ -23,8 +23,8 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
-  private static final String API_KEY_HEADER = "x-api-key";
-  private static final String SERVICE_NAME_HEADER = "x-service-name";
+  private static final String API_KEY_HEADER = "X-API-KEY";
+  private static final String SERVICE_NAME_HEADER = "X-SERVICE-NAME";
 
   private final SecurityProperty securityProperty;
 

--- a/src/main/java/sopt/makers/authentication/support/value/SecurityProperty.java
+++ b/src/main/java/sopt/makers/authentication/support/value/SecurityProperty.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.support.value;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -8,7 +9,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record SecurityProperty(Api api, Jwt jwt) {
 
   @ConfigurationProperties(prefix = "security.api")
-  public record Api(String key, List<String> securedEndpoints) {}
+  public record Api(Map<String, String> keys, List<String> securedEndpoints) {}
 
   @ConfigurationProperties(prefix = "security.jwt")
   public record Jwt(Secret secret) {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -6,6 +6,7 @@ spring:
       - classpath:jpa.yaml
       - classpath:external.yaml
       - classpath:security.yaml
+      - classpath:monitoring.yaml
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -12,9 +12,3 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: ${DB_DRIVER_CLASS}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -5,15 +5,10 @@ spring:
     import:
       - classpath:jpa.yaml
       - classpath:external.yaml
+      - classpath:monitoring.yaml
       - classpath:security.yaml
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: ${DB_DRIVER_CLASS}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -6,6 +6,7 @@ spring:
       - classpath:jpa.yaml
       - classpath:external.yaml
       - classpath:security.yaml
+      - classpath:monitoring.yaml
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -12,9 +12,3 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: ${DB_DRIVER_CLASS}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health

--- a/src/main/resources/monitoring.yaml
+++ b/src/main/resources/monitoring.yaml
@@ -1,0 +1,24 @@
+management:
+  server:
+    port: ${ACTUATOR_PORT}
+  health:
+    redis:
+      enabled: false
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
+      base-path: ${ACTUATOR_PATH}
+  endpoint:
+    health:
+      enabled: true
+    info:
+      enabled: true
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true

--- a/src/main/resources/monitoring.yaml
+++ b/src/main/resources/monitoring.yaml
@@ -1,6 +1,4 @@
 management:
-  server:
-    port: ${ACTUATOR_PORT}
   health:
     redis:
       enabled: false

--- a/src/main/resources/security.yaml
+++ b/src/main/resources/security.yaml
@@ -9,6 +9,7 @@ security:
     key: ${X_API_KEY}
     secured-endpoints:
       - ${GET_PUBLIC_KEY}
+      - ${ACTUATOR_PATH}
 
   jwt:
     secret:

--- a/src/main/resources/security.yaml
+++ b/src/main/resources/security.yaml
@@ -6,7 +6,13 @@ spring.config.activate.on-profile:
 
 security:
   api:
-    key: ${X_API_KEY}
+    keys:
+      playground: ${PLAYGROUND_X_API_KEY}
+      crew: ${CREW_X_API_KEY}
+      app: ${APP_X_API_KEY}
+      admin: ${ADMIN_X_API_KEY}
+      platform: ${PLATFORM_X_API_KEY}
+      monitoring: ${MONITORING_X_API_KEY}
     secured-endpoints:
       - ${GET_PUBLIC_KEY}
       - ${ACTUATOR_PATH}

--- a/src/test/java/sopt/makers/authentication/support/value/SecurityPropertyTest.java
+++ b/src/test/java/sopt/makers/authentication/support/value/SecurityPropertyTest.java
@@ -20,7 +20,7 @@ public class SecurityPropertyTest {
   @DisplayName("SecurityProperty 값 확인")
   void checkSecurityProperty() {
     assertThat(securityProperty).isNotNull();
-    assertThat(securityProperty.api().key()).isNotNull();
+    assertThat(securityProperty.api().keys()).isNotNull();
     assertThat(securityProperty.api().securedEndpoints()).isNotNull();
     assertThat(securityProperty.jwt().secret()).isNotNull();
     assertThat(securityProperty.jwt().secret().rsa()).isNotNull();


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #69

## Work Description ✏️
- 프로메테우스와 그라파나로 구축된 모니터링 서버와 연결하기 위한 셋팅을 해주었습니다!
- 또한 actuator에서 다음 경로를 허용해주었어요
  - info, metrics, prometheus
- apiKey를 각 팀마다 다르게 사용할 수 있도록 security.yaml 구조를 변경해주었습니다!
- 또한 actuator에 대한 port와 base_path를 환경변수화하고 INTERNAL_SERVICE ROLE을 가질때에만 허용해주었어요
- 앞으로 할일은 다음과 같아요
  - [x] 배포 스크립트에서 health check 경로 및 header 추가
  - [x] dev.env 변경 (S3, notion)

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- user의 role(enum)에 INTERNAL_SERVICE를 같이 관리하는게 어색한 것 같아 일단은 ApiKeyAuthentication내에서 String으로 생성하도록 구현했는데 더 좋은 방법이 있을지 플포밍들의 생각이 궁금해요.. ...!!!!