### PR TITLE
[FIX/#71] toJSONObject를 사용하여 Nimbus 라이브러리가 기대하는 JWK 표준 포맷으로 공개키를 반환하도록 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthKeyApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthKeyApiController.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nimbusds.jose.jwk.JWKSet;
+
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -17,6 +19,7 @@ public class AuthKeyApiController implements AuthKeyApi {
   @Override
   @GetMapping("${security.api.secured-endpoints[0]}")
   public ResponseEntity<?> retrievePublicJwks() {
-    return ResponseEntity.status(HttpStatus.OK).body(jwksRetrieveUsecase.retrievePublicKey());
+    JWKSet jwkSet = jwksRetrieveUsecase.retrievePublicKey();
+    return ResponseEntity.status(HttpStatus.OK).body(jwkSet.toJSONObject(true));
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #71

## Work Description ✏️
- Nimbus 라이브러리가 기대하는 JWK 표준 포맷으로 공개키가 조회되지 않는 문제가 있었습니다
- **as-is**
```
{
  "keys": [
    {
      "keyStore": null,
      "private": false,
      "firstFactorCRTExponent": null,
      "secondFactorCRTExponent": null,
      "modulus": {},
      "otherPrimes": [],
      "requiredParams": {
        "e": "AQAB",
        "kty": "RSA",
        "n": "{내용}"
      },
      "publicExponent": {},
      "privateExponent": null,
      "firstPrimeFactor": null,
      "secondPrimeFactor": null,
      "firstCRTCoefficient": null,
      "algorithm": {
        "name": "RS512",
        "requirement": "OPTIONAL"
      },
      "x509CertSHA256Thumbprint": null,
      "keyType": {
        "value": "RSA",
        "requirement": "REQUIRED"
      },
      "keyUse": {
        "value": "sig"
      },
      "x509CertURL": null,
      "issueTime": null,
      "keyID": "{KEY_ID}",
      "keyOperations": null,
      "x509CertThumbprint": null,
      "x509CertChain": null,
      "parsedX509CertChain": null,
      "notBeforeTime": null,
      "expirationTime": null
    }
  ],
  "empty": false,
  "additionalMembers": {}
}
```
- **to-be**
```
{
  "keys": [
    {
      "kty": "RSA",
      "e": "AQAB",
      "use": "sig",
      "kid": "{KEY_ID}",
      "alg": "RS512",
      "n": "{내용}"
    }
  ]
}
```

- `JWKSet.toJSONObject(true)`를 사용하여 JWT 검증에 필요한 공개 키 정보를 JWK(JSON Web Key) 형식으로 안전하게 응답하도록 설정해주었습니다
- `true` 파라미터는 private 키를 제외하고 public key 정보만 포함하도록 명시하는 플래그입니다.
- Nimbus 라이브러리는 이 옵션이 설정되지 않으면 private key도 포함할 수 있기 때문에, 공개적으로 노출되는 엔드포인트에서 반드시 `true`를 설정해야 한다고 합니다.
- 이 방식은 `RSAPublicKey` 객체를 직접 반환할 때 발생할 수 있는 직렬화 오류(`RSAPublicKeyImpl 접근 불가`)를 방지하며, JWK 규격에 맞는 응답을 생성할 수 있었습니다.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 인증 가이드라인 서버와의 test api에서 문제 없이 연결된 내용을 캡쳐합니다!
<img width="816" alt="image" src="https://github.com/user-attachments/assets/39977d7d-c625-47eb-9243-200f9a42c760" />
