### PR TITLE
[FIX/#73] 웹 refresh 로직에서 Cookie로부터 refresh 토큰을 조회해오도록 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -1,5 +1,8 @@
 package sopt.makers.authentication.application.auth.api;
 
+import static sopt.makers.authentication.support.constant.JwtConstant.ACCESS_TOKEN_HEADER;
+import static sopt.makers.authentication.support.constant.JwtConstant.REFRESH_TOKEN_HEADER;
+
 import sopt.makers.authentication.application.auth.dto.request.AuthRequest;
 import sopt.makers.authentication.application.auth.dto.response.AuthResponse;
 import sopt.makers.authentication.support.code.domain.success.AuthSuccess;
@@ -14,6 +17,7 @@ import sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUs
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -85,25 +89,10 @@ public class AuthApiController implements AuthApi {
   }
 
   @Override
-  @PostMapping("/refresh/app")
-  public ResponseEntity<BaseResponse<?>> refreshTokenFromApp(
-      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo) {
-
-    AuthenticateTokenInfo tokenInfo =
-        authenticateSocialAccountUsecase.refresh(authenticationTokenInfo.toCommand());
-
-    return ResponseUtil.success(
-        AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
-        AuthResponse.AuthenticateSocialAuthInfoForApp.of(
-            tokenInfo.accessToken(), tokenInfo.refreshToken()));
-  }
-
-  @Override
   @PostMapping("/refresh/web")
   public ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(
-      @RequestHeader("accessToken") String accessToken,
-      @RequestHeader("refreshToken") String refreshToken) {
-
+      @RequestHeader(ACCESS_TOKEN_HEADER) String accessToken,
+      @CookieValue(REFRESH_TOKEN_HEADER) String refreshToken) {
     AuthRequest.AuthenticationTokenInfo authenticationTokenInfo =
         new AuthRequest.AuthenticationTokenInfo(accessToken, refreshToken);
 
@@ -115,5 +104,19 @@ public class AuthApiController implements AuthApi {
         AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
         headers,
         AuthResponse.AuthenticateSocialAuthInfoForWeb.of(tokenInfo.accessToken()));
+  }
+
+  @Override
+  @PostMapping("/refresh/app")
+  public ResponseEntity<BaseResponse<?>> refreshTokenFromApp(
+      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo) {
+
+    AuthenticateTokenInfo tokenInfo =
+        authenticateSocialAccountUsecase.refresh(authenticationTokenInfo.toCommand());
+
+    return ResponseUtil.success(
+        AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
+        AuthResponse.AuthenticateSocialAuthInfoForApp.of(
+            tokenInfo.accessToken(), tokenInfo.refreshToken()));
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -1,6 +1,5 @@
 package sopt.makers.authentication.application.auth.api;
 
-import static sopt.makers.authentication.support.constant.JwtConstant.ACCESS_TOKEN_HEADER;
 import static sopt.makers.authentication.support.constant.JwtConstant.REFRESH_TOKEN_HEADER;
 
 import sopt.makers.authentication.application.auth.dto.request.AuthRequest;
@@ -91,7 +90,7 @@ public class AuthApiController implements AuthApi {
   @Override
   @PostMapping("/refresh/web")
   public ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(
-      @RequestHeader(ACCESS_TOKEN_HEADER) String accessToken,
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
       @CookieValue(REFRESH_TOKEN_HEADER) String refreshToken) {
     AuthRequest.AuthenticationTokenInfo authenticationTokenInfo =
         new AuthRequest.AuthenticationTokenInfo(accessToken, refreshToken);

--- a/src/main/java/sopt/makers/authentication/support/constant/JwtConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/JwtConstant.java
@@ -4,5 +4,6 @@ public class JwtConstant {
 
   public static final String TOKEN_HEADER = "Bearer ";
   public static final String[] SERVICE_NAMES = {"playground", "crew", "app", "admin"};
-  public static final String REFRESH_TOKEN_HEADER = "refresh-token";
+  public static final String ACCESS_TOKEN_HEADER = "Access-Token";
+  public static final String REFRESH_TOKEN_HEADER = "Refresh-Token";
 }

--- a/src/main/java/sopt/makers/authentication/support/constant/JwtConstant.java
+++ b/src/main/java/sopt/makers/authentication/support/constant/JwtConstant.java
@@ -3,7 +3,5 @@ package sopt.makers.authentication.support.constant;
 public class JwtConstant {
 
   public static final String TOKEN_HEADER = "Bearer ";
-  public static final String[] SERVICE_NAMES = {"playground", "crew", "app", "admin"};
-  public static final String ACCESS_TOKEN_HEADER = "Access-Token";
   public static final String REFRESH_TOKEN_HEADER = "Refresh-Token";
 }

--- a/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthRefreshTokenProvider.java
+++ b/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthRefreshTokenProvider.java
@@ -1,8 +1,5 @@
 package sopt.makers.authentication.support.jwt.provider;
 
-import static sopt.makers.authentication.support.jwt.provider.JwtTokenUtil.addPrefix;
-import static sopt.makers.authentication.support.jwt.provider.JwtTokenUtil.extract;
-
 import sopt.makers.authentication.support.jwt.JwtProvider;
 import sopt.makers.authentication.support.jwt.token.JwtRefreshToken;
 import sopt.makers.authentication.support.value.SecurityProperty.Jwt.Secret.Expiration;
@@ -40,14 +37,13 @@ public class JwtAuthRefreshTokenProvider implements JwtProvider<String> {
 
   @Override
   public String parse(String requestToken) {
-    String token = extract(requestToken);
-    Jwt jwt = jwtDecoder.decode(token);
+    Jwt jwt = jwtDecoder.decode(requestToken);
 
     JwtRefreshToken jwtRefreshToken = JwtRefreshToken.createRefreshToken(jwt);
     jwtRefreshToken.validateExpire();
     JwtRefreshToken refreshedToken = refresh();
 
-    return addPrefix(refreshedToken.getToken());
+    return refreshedToken.getToken();
   }
 
   private JwtRefreshToken refresh() {

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -46,11 +46,13 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
   public AuthenticateTokenInfo refresh(AuthenticateTokenInfo command) {
     String refreshToken = command.refreshToken();
 
+    // 여기서 Bearer 없이 검증하도록하고
     jwtAuthRefreshTokenProvider.parse(refreshToken);
     CustomAuthentication customAuthentication =
         jwtAuthAccessTokenProvider.parse(command.accessToken());
 
     String renewedAccessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
+    // 새로 생성해도 Bearer 안붙이도
     String renewedRefreshToken = jwtAuthRefreshTokenProvider.generate(renewedAccessToken);
     return AuthenticateTokenInfo.of(renewedAccessToken, renewedRefreshToken);
   }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -46,13 +46,11 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
   public AuthenticateTokenInfo refresh(AuthenticateTokenInfo command) {
     String refreshToken = command.refreshToken();
 
-    // 여기서 Bearer 없이 검증하도록하고
     jwtAuthRefreshTokenProvider.parse(refreshToken);
     CustomAuthentication customAuthentication =
         jwtAuthAccessTokenProvider.parse(command.accessToken());
 
     String renewedAccessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
-    // 새로 생성해도 Bearer 안붙이도
     String renewedRefreshToken = jwtAuthRefreshTokenProvider.generate(renewedAccessToken);
     return AuthenticateTokenInfo.of(renewedAccessToken, renewedRefreshToken);
   }

--- a/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
@@ -2,7 +2,6 @@ package sopt.makers.authentication.jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static sopt.makers.authentication.support.jwt.provider.JwtTokenUtil.addPrefix;
 
 import sopt.makers.authentication.support.exception.support.TokenException;
 import sopt.makers.authentication.support.jwt.provider.JwtAuthRefreshTokenProvider;
@@ -69,7 +68,7 @@ public class JwtRefreshTokenTest {
     String token = jwtAuthRefreshTokenProvider.generate(accessToken);
 
     // When
-    String refreshedToken = jwtAuthRefreshTokenProvider.parse(TOKEN_HEADER + token);
+    String refreshedToken = jwtAuthRefreshTokenProvider.parse(token);
 
     // then
     assertThat(refreshedToken).isNotEqualTo(token);
@@ -82,7 +81,7 @@ public class JwtRefreshTokenTest {
     JwtClaimsSet jwtClaimsSet =
         JwtClaimsSet.builder().expiresAt(Instant.now().minusSeconds(1)).build();
     Jwt jwt = jwtEncoder.encode(JwtEncoderParameters.from(jwtClaimsSet));
-    String token = addPrefix(jwt.getTokenValue());
+    String token = jwt.getTokenValue();
 
     // When & then
     assertThatThrownBy(() -> jwtAuthRefreshTokenProvider.parse(token))

--- a/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import sopt.makers.authentication.support.exception.support.TokenException;
 import sopt.makers.authentication.support.jwt.provider.JwtAuthRefreshTokenProvider;
 
-import java.io.IOException;
 import java.time.Instant;
 
 import org.junit.jupiter.api.DisplayName;
@@ -62,7 +61,7 @@ public class JwtRefreshTokenTest {
 
   @Test
   @DisplayName("RefreshToken 갱신")
-  public void refresh_jwt_refresh_token() throws IOException {
+  public void refresh_jwt_refresh_token() {
     // Given
     String accessToken = "Bearer ey.d.d";
     String token = jwtAuthRefreshTokenProvider.generate(accessToken);
@@ -76,7 +75,7 @@ public class JwtRefreshTokenTest {
 
   @Test
   @DisplayName("RefreshToken 만료시간 검증")
-  public void validate_jwt_refresh_token() throws IOException {
+  public void validate_jwt_refresh_token() {
     // Given
     JwtClaimsSet jwtClaimsSet =
         JwtClaimsSet.builder().expiresAt(Instant.now().minusSeconds(1)).build();


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #73 

## Work Description ✏️
- `as-is`: 웹 refresh 토큰을 Header로부터 추출
- `to-be`: 웹 refresh 토큰을 Cookie로부터 조회
- refresh 토큰 parse 로직에서 "Bearer " prefix를 붙이지 않도록 수정했습니다
- refresh 토큰 관련 테스트코드 로직에서도 prefix를 제외하고 검증할 수 있도록 수정했습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- `@CookieValue` 어노테이션을 통해 쿠키를 가져오도록 했는데 저희 프로젝트에서 CookieUtil 클래스가 이미 존재하는 상황이라 혹시 해당 클래스에서 Cookie를 추출하도록 변경하는게 더 좋을 것 같다면 편하게 의견주세요!
- 일단은 코드를 많이 추가하지 않는 선에서 수정해보았습니다!