### PR TITLE
[FEAT/#78] jwt 토큰 header에 kid가 포함되도록 변경

### DIFF
--- a/src/main/java/sopt/makers/authentication/support/config/JwtRSAKeyConfiguration.java
+++ b/src/main/java/sopt/makers/authentication/support/config/JwtRSAKeyConfiguration.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.support.config;
 
 import sopt.makers.authentication.support.jwt.RSAKeyManager;
+import sopt.makers.authentication.support.value.SecurityProperty;
 
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -26,13 +27,14 @@ import lombok.RequiredArgsConstructor;
 public class JwtRSAKeyConfiguration {
 
   private final RSAKeyManager keyManager;
+  private final SecurityProperty securityProperty;
 
   @Bean
   public JwtEncoder jwtEncoder() {
     RSAPublicKey publicKey = keyManager.getPublicKey();
     RSAPrivateKey privateKey = keyManager.getPrivateKey();
-
-    JWK jwk = new RSAKey.Builder(publicKey).privateKey(privateKey).build();
+    String keyId = securityProperty.jwt().secret().rsa().keyId();
+    JWK jwk = new RSAKey.Builder(publicKey).privateKey(privateKey).keyID(keyId).build();
     JWKSource<SecurityContext> jwks = new ImmutableJWKSet<>(new JWKSet(jwk));
     return new NimbusJwtEncoder(jwks);
   }

--- a/src/main/java/sopt/makers/authentication/support/jwt/JwtProvider.java
+++ b/src/main/java/sopt/makers/authentication/support/jwt/JwtProvider.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 public interface JwtProvider<T> {
 
-  String generateJwtAuthToken(final T value);
+  String generateJwt(final T value);
 
   T parse(final String token) throws IOException;
 }

--- a/src/main/java/sopt/makers/authentication/support/jwt/JwtProvider.java
+++ b/src/main/java/sopt/makers/authentication/support/jwt/JwtProvider.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 public interface JwtProvider<T> {
 
-  String generate(final T value);
+  String generateJwtAuthToken(final T value);
 
   T parse(final String token) throws IOException;
 }

--- a/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthAccessTokenProvider.java
+++ b/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthAccessTokenProvider.java
@@ -24,31 +24,50 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class JwtAuthAccessTokenProvider implements JwtProvider<CustomAuthentication> {
-
+  private static final String ROLES = "roles";
   private final JwtEncoder jwtEncoder;
   private final JwtDecoder jwtDecoder;
   private final SecurityProperty securityProperty;
 
   @Override
-  public String generate(CustomAuthentication authentication) {
-
+  public String generateJwtAuthToken(CustomAuthentication authentication) {
     String subject = authentication.getPrincipal().toString();
     String issuer = securityProperty.jwt().secret().issuer().issuerName();
     Instant now = Instant.now();
-    Instant expiration =
-        now.plusSeconds(securityProperty.jwt().secret().expiration().accessTokenExpiration());
-    List<String> roles =
-        authentication.getAuthorities().stream()
-            .map(GrantedAuthority::getAuthority)
-            .collect(Collectors.toUnmodifiableList());
-
-    JwtClaimsSet claimsSet = generateClaimSet(subject, issuer, now, expiration, roles);
-    JwtAccessToken jwtAccessToken =
-        JwtAccessToken.createJwtAccessToken(
-            jwtEncoder.encode(JwtEncoderParameters.from(claimsSet)));
+    Instant expiration = calculateExpiration(now);
+    List<String> roles = extractRoles(authentication);
+    JwtClaimsSet claimsSet = generateClaimsSet(subject, issuer, now, expiration, roles);
+    JwtAccessToken jwtAccessToken = generateJwtAccessToken(claimsSet);
 
     jwtAccessToken.validate(securityProperty);
     return jwtAccessToken.getToken();
+  }
+
+  private Instant calculateExpiration(Instant now) {
+    long seconds = securityProperty.jwt().secret().expiration().accessTokenExpiration();
+    return now.plusSeconds(seconds);
+  }
+
+  private List<String> extractRoles(CustomAuthentication authentication) {
+    return authentication.getAuthorities().stream()
+        .map(GrantedAuthority::getAuthority)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  private JwtClaimsSet generateClaimsSet(
+      String subject, String issuer, Instant issuedAt, Instant expiresAt, List<String> roles) {
+    return JwtClaimsSet.builder()
+        .subject(subject)
+        .issuer(issuer)
+        .issuedAt(issuedAt)
+        .expiresAt(expiresAt)
+        .claim(ROLES, roles)
+        .build();
+  }
+
+  private JwtAccessToken generateJwtAccessToken(JwtClaimsSet claims) {
+    Jwt jwt = jwtEncoder.encode(JwtEncoderParameters.from(claims));
+    return JwtAccessToken.createJwtAccessToken(jwt);
   }
 
   @Override
@@ -57,16 +76,5 @@ public class JwtAuthAccessTokenProvider implements JwtProvider<CustomAuthenticat
     Jwt accessToken = jwtDecoder.decode(token);
     JwtAccessToken jwtAccessToken = JwtAccessToken.createJwtAccessToken(accessToken);
     return jwtAccessToken.parse();
-  }
-
-  private JwtClaimsSet generateClaimSet(
-      String subject, String issuer, Instant issuedAt, Instant expiresAt, List<String> roles) {
-    return JwtClaimsSet.builder()
-        .subject(subject)
-        .issuer(issuer)
-        .issuedAt(issuedAt)
-        .expiresAt(expiresAt)
-        .claim("roles", roles)
-        .build();
   }
 }

--- a/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthAccessTokenProvider.java
+++ b/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthAccessTokenProvider.java
@@ -30,7 +30,7 @@ public class JwtAuthAccessTokenProvider implements JwtProvider<CustomAuthenticat
   private final SecurityProperty securityProperty;
 
   @Override
-  public String generateJwtAuthToken(CustomAuthentication authentication) {
+  public String generateJwt(CustomAuthentication authentication) {
     String subject = authentication.getPrincipal().toString();
     String issuer = securityProperty.jwt().secret().issuer().issuerName();
     Instant now = Instant.now();

--- a/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthRefreshTokenProvider.java
+++ b/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthRefreshTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtAuthRefreshTokenProvider implements JwtProvider<String> {
   private final Issuer issuer;
 
   @Override
-  public String generate(String accessToken) {
+  public String generateJwtAuthToken(String accessToken) {
     JwtClaimsSet claimsSet = generateClaimSet();
     Jwt jwt = jwtEncoder.encode(JwtEncoderParameters.from(claimsSet));
     JwtRefreshToken jwtRefreshToken = JwtRefreshToken.createRefreshToken(jwt);

--- a/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthRefreshTokenProvider.java
+++ b/src/main/java/sopt/makers/authentication/support/jwt/provider/JwtAuthRefreshTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtAuthRefreshTokenProvider implements JwtProvider<String> {
   private final Issuer issuer;
 
   @Override
-  public String generateJwtAuthToken(String accessToken) {
+  public String generateJwt(String accessToken) {
     JwtClaimsSet claimsSet = generateClaimSet();
     Jwt jwt = jwtEncoder.encode(JwtEncoderParameters.from(claimsSet));
     JwtRefreshToken jwtRefreshToken = JwtRefreshToken.createRefreshToken(jwt);

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -12,6 +12,9 @@ import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 import sopt.makers.authentication.usecase.auth.port.out.UserRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 
+import java.util.List;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -34,10 +37,11 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
             SocialAccount.of(authPlatformId, command.authPlatform()));
     ActivityList activityList = userActivityHistoryRepository.findByUser(user.getId());
     Role role = activityList.getLastActivity().getRole();
-
-    CustomAuthentication customAuthentication = new CustomAuthentication(user.getId(), role);
-    String accessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
-    String refreshToken = jwtAuthRefreshTokenProvider.generate(accessToken);
+    CustomAuthentication customAuthentication =
+        new CustomAuthentication(
+            user.getId(), null, List.of(new SimpleGrantedAuthority(role.name())));
+    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
+    String refreshToken = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
 
     return AuthenticateTokenInfo.of(accessToken, refreshToken);
   }
@@ -50,8 +54,10 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
     CustomAuthentication customAuthentication =
         jwtAuthAccessTokenProvider.parse(command.accessToken());
 
-    String renewedAccessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
-    String renewedRefreshToken = jwtAuthRefreshTokenProvider.generate(renewedAccessToken);
+    String renewedAccessToken =
+        jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
+    String renewedRefreshToken =
+        jwtAuthRefreshTokenProvider.generateJwtAuthToken(renewedAccessToken);
     return AuthenticateTokenInfo.of(renewedAccessToken, renewedRefreshToken);
   }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/AuthenticateSocialAccountService.java
@@ -40,8 +40,8 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
     CustomAuthentication customAuthentication =
         new CustomAuthentication(
             user.getId(), null, List.of(new SimpleGrantedAuthority(role.name())));
-    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
-    String refreshToken = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
+    String refreshToken = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
 
     return AuthenticateTokenInfo.of(accessToken, refreshToken);
   }
@@ -54,10 +54,8 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
     CustomAuthentication customAuthentication =
         jwtAuthAccessTokenProvider.parse(command.accessToken());
 
-    String renewedAccessToken =
-        jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
-    String renewedRefreshToken =
-        jwtAuthRefreshTokenProvider.generateJwtAuthToken(renewedAccessToken);
+    String renewedAccessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
+    String renewedRefreshToken = jwtAuthRefreshTokenProvider.generateJwt(renewedAccessToken);
     return AuthenticateTokenInfo.of(renewedAccessToken, renewedRefreshToken);
   }
 }

--- a/src/test/java/sopt/makers/authentication/jwt/JwtAccessTokenTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtAccessTokenTest.java
@@ -49,7 +49,7 @@ public class JwtAccessTokenTest {
     CustomAuthentication customAuthentication = new CustomAuthentication("test", "test");
 
     // When
-    String accessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
 
     // Then
     assertThat(accessToken).isNotNull();
@@ -60,7 +60,7 @@ public class JwtAccessTokenTest {
   void decode_jwt_access_token() {
     // Given
     CustomAuthentication customAuthentication = new CustomAuthentication("test", "test");
-    String accessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
 
     // When
     Jwt jwt = jwtDecoder.decode(accessToken);
@@ -75,7 +75,7 @@ public class JwtAccessTokenTest {
   void parse_jwt_access_token() throws IOException {
     // Given
     CustomAuthentication customAuthentication = new CustomAuthentication("test", "test");
-    String accessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
 
     // when
     CustomAuthentication parsedAuthentication =
@@ -120,7 +120,7 @@ public class JwtAccessTokenTest {
   void decode_jwt_access_token_with_public_key() throws ParseException, JOSEException {
     // Arrange
     CustomAuthentication customAuthentication = new CustomAuthentication("test", "test");
-    String accessToken = jwtAuthAccessTokenProvider.generate(customAuthentication);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
 
     SignedJWT signedJWT = SignedJWT.parse(accessToken);
     JWKSet info = jwksRetrieveUsecase.retrievePublicKey();

--- a/src/test/java/sopt/makers/authentication/jwt/JwtAccessTokenTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtAccessTokenTest.java
@@ -49,7 +49,7 @@ public class JwtAccessTokenTest {
     CustomAuthentication customAuthentication = new CustomAuthentication("test", "test");
 
     // When
-    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
 
     // Then
     assertThat(accessToken).isNotNull();
@@ -60,7 +60,7 @@ public class JwtAccessTokenTest {
   void decode_jwt_access_token() {
     // Given
     CustomAuthentication customAuthentication = new CustomAuthentication("test", "test");
-    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
 
     // When
     Jwt jwt = jwtDecoder.decode(accessToken);
@@ -75,7 +75,7 @@ public class JwtAccessTokenTest {
   void parse_jwt_access_token() throws IOException {
     // Given
     CustomAuthentication customAuthentication = new CustomAuthentication("test", "test");
-    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
 
     // when
     CustomAuthentication parsedAuthentication =
@@ -120,7 +120,7 @@ public class JwtAccessTokenTest {
   void decode_jwt_access_token_with_public_key() throws ParseException, JOSEException {
     // Arrange
     CustomAuthentication customAuthentication = new CustomAuthentication("test", "test");
-    String accessToken = jwtAuthAccessTokenProvider.generateJwtAuthToken(customAuthentication);
+    String accessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
 
     SignedJWT signedJWT = SignedJWT.parse(accessToken);
     JWKSet info = jwksRetrieveUsecase.retrievePublicKey();

--- a/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
@@ -35,10 +35,10 @@ public class JwtRefreshTokenTest {
   public void generate_jwt_refresh_token() {
     // Given
     String accessToken = "Bearer ey.d.d";
-    String givenToken = jwtAuthRefreshTokenProvider.generate(accessToken);
+    String givenToken = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
 
     // When
-    String expectedToken = jwtAuthRefreshTokenProvider.generate(accessToken);
+    String expectedToken = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
 
     // Then
     assertThat(givenToken).isNotNull();
@@ -50,7 +50,7 @@ public class JwtRefreshTokenTest {
   public void decode_jwt_refresh_token() {
     // Given
     String accessToken = "Bearer ey.d.d";
-    String refreshToken = jwtAuthRefreshTokenProvider.generate(accessToken);
+    String refreshToken = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
 
     // When
     Jwt jwt = jwtDecoder.decode(refreshToken);
@@ -64,7 +64,7 @@ public class JwtRefreshTokenTest {
   public void refresh_jwt_refresh_token() {
     // Given
     String accessToken = "Bearer ey.d.d";
-    String token = jwtAuthRefreshTokenProvider.generate(accessToken);
+    String token = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
 
     // When
     String refreshedToken = jwtAuthRefreshTokenProvider.parse(token);

--- a/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
+++ b/src/test/java/sopt/makers/authentication/jwt/JwtRefreshTokenTest.java
@@ -35,10 +35,10 @@ public class JwtRefreshTokenTest {
   public void generate_jwt_refresh_token() {
     // Given
     String accessToken = "Bearer ey.d.d";
-    String givenToken = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
+    String givenToken = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
 
     // When
-    String expectedToken = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
+    String expectedToken = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
 
     // Then
     assertThat(givenToken).isNotNull();
@@ -50,7 +50,7 @@ public class JwtRefreshTokenTest {
   public void decode_jwt_refresh_token() {
     // Given
     String accessToken = "Bearer ey.d.d";
-    String refreshToken = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
+    String refreshToken = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
 
     // When
     Jwt jwt = jwtDecoder.decode(refreshToken);
@@ -64,7 +64,7 @@ public class JwtRefreshTokenTest {
   public void refresh_jwt_refresh_token() {
     // Given
     String accessToken = "Bearer ey.d.d";
-    String token = jwtAuthRefreshTokenProvider.generateJwtAuthToken(accessToken);
+    String token = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
 
     // When
     String refreshedToken = jwtAuthRefreshTokenProvider.parse(token);


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #78 

## Work Description ✏️
- JWT 발급 시 JOSE Header에 `kid` 값을 추가하여 발급 토큰의 header에서 명시적으로 키 ID를 지정하도록 변경했습니다.
  -  기존에는 keyId를 각 서비스 서버에서 가지고 있다고 생각하고 구현했던 것 같은데,  해당 방식에는 다음과 같은 단점이 존재했습니다
     - 인증 서버에서 키가 교체되면 모든 팀 서버에서 kid를 변경해야 함
     - 서비스 서버가 kid를 직접 관리하면, 인증 서버와 서비스 서버의 kid가 불일치할 수 있음
     - 이로 인해 정상적인 JWT임에도 검증에 실패하게 되고, 사용자 인증이 특정 서비스에서 제대로 이루어지지 않을 가능성이 있음
- 위와 같은 문제점을 해결하고자 리소스(서비스) 서버가 JWT 서명을 검증할 때 JWK 목록에서 정확한 키를 선택할 수 있도록 플로우를 수정했습니다.
  - 이를 위해 인증 서버에서는 다음과 같은 사항을 변경했습니다  
     - `JwtRSAKeyConfiguration`에서 `RSAKey` 생성 시 `.keyID(...)` 설정 추가
     - `NimbusJwtEncoder`를 사용할 때 `kid`가 `header`에 자동 포함되도록 구성
- 또한 `JwtAuthAccessTokenProvider`의 [generate 메서드를 리팩토링](https://github.com/sopt-makers/sopt-auth-backend/pull/79/commits/961757e31fecbe99ef802f5cb242fdd3925e565c) 해보았습니다
- 마지막으로 리소스 서버 가이드라인 프로젝트에서 테스트할 때 토큰에 role이 담겨있지 않아 [role이 반영될 수 있도록 코드를 수정](https://github.com/sopt-makers/sopt-auth-backend/pull/79/commits/7d3b6c0885966d093eab3d920e17b17c999585b6)해주었습니다!

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- role이 담기지 않던 문제를 수정하여 인증 서버 가이드라인에서 role이 잘 출력되는 것을 대신 첨부합니다!
![image](https://github.com/user-attachments/assets/84bf9963-c84d-46ee-ba17-bd091558d454)