### PR TITLE
[FEAT/#81] apple aud 필드를 web/app 분리하여 관리하도록 변경

### DIFF
--- a/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/AppleAuthService.java
@@ -12,6 +12,7 @@ import sopt.makers.authentication.support.value.AppleOAuthProperty;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 
 import org.springframework.stereotype.Component;
 
@@ -64,7 +65,7 @@ public class AppleAuthService implements OAuthService {
 
       boolean isVerifiedSignature = jwt.verify(verifier);
       boolean isCorrectIssuer = jwtClaimsSet.getIssuer().equals(APPLE_ISSUER);
-      boolean isCorrectAudience = jwtClaimsSet.getAudience().contains(appleOAuthProperty.aud());
+      boolean isCorrectAudience = verifyAudience(jwtClaimsSet.getAudience());
       boolean isNotExpired = jwtClaimsSet.getExpirationTime().after(Date.from(Instant.now()));
 
       if (!(isVerifiedSignature && isCorrectIssuer && isCorrectAudience && isNotExpired)) {
@@ -73,5 +74,10 @@ public class AppleAuthService implements OAuthService {
     } catch (JOSEException e) {
       throw new AuthException(AuthFailure.INVALID_ID_TOKEN);
     }
+  }
+
+  private boolean verifyAudience(List<String> audiences) {
+    return audiences.contains(appleOAuthProperty.webAud())
+        || audiences.contains(appleOAuthProperty.appAud());
   }
 }

--- a/src/main/java/sopt/makers/authentication/support/value/AppleOAuthProperty.java
+++ b/src/main/java/sopt/makers/authentication/support/value/AppleOAuthProperty.java
@@ -3,4 +3,4 @@ package sopt.makers.authentication.support.value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "external.oauth.apple")
-public record AppleOAuthProperty(String aud) {}
+public record AppleOAuthProperty(String webAud, String appAud) {}

--- a/src/main/resources/external.yaml
+++ b/src/main/resources/external.yaml
@@ -12,7 +12,8 @@ external:
       phone: ${GABIA_SMS_PHONE}
   oauth:
     apple:
-      aud: ${APPLE_AUD}
+      web-aud: ${APPLE_AUD_WEB}
+      app-aud: ${APPLE_AUD_APP}
     google:
       client:
         id: ${GOOGLE_CLIENT_ID}


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #81

## Work Description ✏️
- 기존에 iOS 앱에서 사용하던 appId(=A)를 이용하여 auth-front(인증 중앙화 페이지)에서 애플로그인을 진행할 수 없다는 문제가 발생했습니다
- 이에 따라 auth-front의 serviceId(=B)에 애플 로그인 설정에서 primary_id를 A로 설정해주고 인증 서버에서 A/B 둘 다 허용하도록 로직 변경하였습니다
- 네이티브 로그인을 분리하게 되면서 비슷한 문제가 구글 로그인에서도 발생할 수 있지 않을까.. 조심스레 예상해봅니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 만약에 석우오빠가 테스트했을 때 웹에서 로그인에 실패하게 된다면 반환되는 sub 필드의 값이 다른 것이므로 네이티브 환경과 웹 환경에서의 user_id를 동일하게 가져갈 수 없다는 문제가 발생하는 것이므로 이에 대한 대안을 생각해보아야 할 것 같습니다!