### PR TITLE
[FIX/#83] UserEntity를 유저 도메인으로 변환시, userActivityHistoryList가 null 또는 비어있는 경우에 대한 처리 추가

### DIFF
--- a/src/main/java/sopt/makers/authentication/database/rdb/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/entity/UserEntity.java
@@ -87,6 +87,9 @@ public class UserEntity extends BaseEntity {
   public User toDomain() {
     SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType);
     Profile profile = Profile.of(name, email, phone, birthday);
+    if (userActivityHistoryList == null || userActivityHistoryList.isEmpty()) {
+      return User.createUser(super.getId(), socialAccount, profile);
+    }
     List<Activity> activityList =
         userActivityHistoryList.stream().map(UserActivityHistoryEntity::toDomain).toList();
     return User.createUser(super.getId(), socialAccount, profile, ActivityList.of(activityList));


### PR DESCRIPTION
## Related Issue 🚀
- closed #83

## Work Description ✏️
- UserEntity를 유저 도메인으로 변환시, userActivityHistoryList가 null 또는 비어있는 경우에 대한 예외처리를 추가하였습니다!
- 회원가입 시에 아래 오류가 나는 상황이었어요!
   - 유저 정보 조회 API 개발하면서, 유저 도메인 변환시 `Activity`도 함께 변환하는 것으로 `toDomain()` 메서드를 다음과 같이 수정했는데, 회원가입 시에도 해당 메서드를 사용하는 부분에 대해 미쳐 생각하지 못했어서,, 해당 부분에 대한 null 처리를 못했었습니다..!! 
  
`2025-05-05T09:14:32.892Z ERROR 1 --- [nio-8080-exec-3] s.m.a.s.e.ApplicationExceptionHandler    : Cannot invoke "java.util.List.stream()" because "this.userActivityHistoryList" is null`


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
