### PR TITLE
[FEAT/#80] 유저 정보 수정 API 구현

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/user/api/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/application/user/api/UserApi.java
@@ -3,17 +3,28 @@ package sopt.makers.authentication.application.user.api;
 import static sopt.makers.authentication.support.constant.SystemConstant.API_KEY_HEADER;
 import static sopt.makers.authentication.support.constant.SystemConstant.SERVICE_NAME_HEADER;
 
+import sopt.makers.authentication.application.user.dto.request.UserRequest;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 public interface UserApi {
-  ResponseEntity<BaseResponse<?>> getUserInformation(
+  ResponseEntity<BaseResponse<?>> getUserProfile(
       @RequestHeader(API_KEY_HEADER) String apiKey,
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
       @RequestParam List<Long> userIds);
+
+  ResponseEntity<BaseResponse<?>> updateUserProfile(
+      @RequestHeader(API_KEY_HEADER) String apiKey,
+      @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
+      @PathVariable Long userId,
+      @Valid @RequestBody UserRequest.UserProfileInfo userProfileInfo);
 }

--- a/src/main/java/sopt/makers/authentication/application/user/api/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/user/api/UserApiController.java
@@ -3,17 +3,24 @@ package sopt.makers.authentication.application.user.api;
 import static sopt.makers.authentication.support.constant.SystemConstant.API_KEY_HEADER;
 import static sopt.makers.authentication.support.constant.SystemConstant.SERVICE_NAME_HEADER;
 
+import sopt.makers.authentication.application.user.dto.request.UserRequest;
 import sopt.makers.authentication.application.user.dto.response.UserResponse;
 import sopt.makers.authentication.support.code.domain.success.UserSuccess;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 import sopt.makers.authentication.support.util.ResponseUtil;
 import sopt.makers.authentication.support.validator.UserIdValidator;
-import sopt.makers.authentication.usecase.user.port.in.GetUserInformationUsecase;
+import sopt.makers.authentication.usecase.user.port.in.GetUserProfileUsecase;
+import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,24 +29,35 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserApiController implements UserApi {
-  private final GetUserInformationUsecase getUserInformationUsecase;
+  private final GetUserProfileUsecase getUserProfileUsecase;
+  private final UpdateUserProfileUsecase updateUserProfileUsecase;
   private final UserIdValidator userIdValidator;
 
-  @GetMapping("/users")
-  public ResponseEntity<BaseResponse<?>> getUserInformation(
+  @GetMapping("/")
+  public ResponseEntity<BaseResponse<?>> getUserProfile(
       @RequestHeader(API_KEY_HEADER) String apiKey,
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
       @RequestParam List<Long> userIds) {
     userIdValidator.validateUserIds(userIds);
-
-    List<GetUserInformationUsecase.UserProfileAndActivityInfo> userInformation =
-        getUserInformationUsecase.getUserInformation(userIds);
+    List<GetUserProfileUsecase.UserProfileAndActivityInfo> userInformation =
+        getUserProfileUsecase.getUserInformation(userIds);
 
     return ResponseUtil.success(
-        UserSuccess.GET_USER_INFORMATION,
-        UserResponse.UserProfileAndActivity.from(userInformation));
+        UserSuccess.GET_USER_PROFILE, UserResponse.UserProfileAndActivity.from(userInformation));
+  }
+
+  @PutMapping("/{userId}")
+  public ResponseEntity<BaseResponse<?>> updateUserProfile(
+      @RequestHeader(API_KEY_HEADER) String apiKey,
+      @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
+      @PathVariable Long userId,
+      @Valid @RequestBody UserRequest.UserProfileInfo userProfileInfo) {
+    userIdValidator.validateUserIds(userId);
+    updateUserProfileUsecase.updateUserProfile(userProfileInfo.toCommand());
+
+    return ResponseUtil.success(UserSuccess.UPDATE_USER_PROFILE);
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/user/api/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/user/api/UserApiController.java
@@ -36,7 +36,7 @@ public class UserApiController implements UserApi {
   private final UpdateUserProfileUsecase updateUserProfileUsecase;
   private final UserIdValidator userIdValidator;
 
-  @GetMapping("/")
+  @GetMapping("")
   public ResponseEntity<BaseResponse<?>> getUserProfile(
       @RequestHeader(API_KEY_HEADER) String apiKey,
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
@@ -56,7 +56,7 @@ public class UserApiController implements UserApi {
       @PathVariable Long userId,
       @Valid @RequestBody UserRequest.UserProfileInfo userProfileInfo) {
     userIdValidator.validateUserIds(userId);
-    updateUserProfileUsecase.updateUserProfile(userProfileInfo.toCommand());
+    updateUserProfileUsecase.updateUserProfile(userProfileInfo.toCommand(userId));
 
     return ResponseUtil.success(UserSuccess.UPDATE_USER_PROFILE);
   }

--- a/src/main/java/sopt/makers/authentication/application/user/dto/request/UserRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/user/dto/request/UserRequest.java
@@ -1,0 +1,40 @@
+package sopt.makers.authentication.application.user.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase.SoptActivityCommand;
+import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase.UserProfileCommand;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = PRIVATE)
+public class UserRequest {
+  public record UserProfileInfo(
+      String profileImage,
+      LocalDate birthday,
+      @NotNull(message = "핸드폰 번호는 필수 입력 값입니다.") String phone,
+      @NotNull(message = "이메일은 필수 입력 값입니다.")
+          @Pattern(
+              regexp =
+                  "^[0-9a-zA-Z]([-_￦.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_￦.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$")
+          String email,
+      List<SoptActivityInfo> soptActivities) {
+    public UserProfileCommand toCommand() {
+      List<SoptActivityCommand> activityCommandList =
+          soptActivities.stream().map(SoptActivityInfo::toCommand).toList();
+      return UserProfileCommand.of(profileImage, birthday, phone, email, activityCommandList);
+    }
+  }
+
+  public record SoptActivityInfo(Long activityId, int generation, String part, String team) {
+    public SoptActivityCommand toCommand() {
+      return SoptActivityCommand.of(activityId, generation, part, team);
+    }
+  }
+}

--- a/src/main/java/sopt/makers/authentication/application/user/dto/request/UserRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/user/dto/request/UserRequest.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = PRIVATE)
 public class UserRequest {
   public record UserProfileInfo(
+      Long userId,
       String profileImage,
       LocalDate birthday,
       @NotNull(message = "핸드폰 번호는 필수 입력 값입니다.") String phone,
@@ -25,16 +26,17 @@ public class UserRequest {
                   "^[0-9a-zA-Z]([-_￦.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_￦.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$")
           String email,
       List<SoptActivityInfo> soptActivities) {
-    public UserProfileCommand toCommand() {
+    public UserProfileCommand toCommand(Long userId) {
       List<SoptActivityCommand> activityCommandList =
           soptActivities.stream().map(SoptActivityInfo::toCommand).toList();
-      return UserProfileCommand.of(profileImage, birthday, phone, email, activityCommandList);
+      return UserProfileCommand.of(
+          userId, profileImage, birthday, phone, email, activityCommandList);
     }
   }
 
-  public record SoptActivityInfo(Long activityId, int generation, String part, String team) {
+  public record SoptActivityInfo(Long activityId, String team) {
     public SoptActivityCommand toCommand() {
-      return SoptActivityCommand.of(activityId, generation, part, team);
+      return SoptActivityCommand.of(activityId, team);
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
@@ -2,7 +2,7 @@ package sopt.makers.authentication.application.user.dto.response;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import sopt.makers.authentication.usecase.user.port.in.GetUserInformationUsecase;
+import sopt.makers.authentication.usecase.user.port.in.GetUserProfileUsecase;
 
 import java.util.List;
 
@@ -19,7 +19,7 @@ public final class UserResponse {
       String email,
       List<UserActivityDetail> soptActivities) {
     public static UserProfileAndActivity from(
-        GetUserInformationUsecase.UserProfileAndActivityInfo userProfileAndActivityInfo) {
+        GetUserProfileUsecase.UserProfileAndActivityInfo userProfileAndActivityInfo) {
       List<UserActivityDetail> soptActivities =
           userProfileAndActivityInfo.soptActivities().stream()
               .map(UserActivityDetail::from)
@@ -36,14 +36,13 @@ public final class UserResponse {
     }
 
     public static List<UserProfileAndActivity> from(
-        List<GetUserInformationUsecase.UserProfileAndActivityInfo> infoList) {
+        List<GetUserProfileUsecase.UserProfileAndActivityInfo> infoList) {
       return infoList.stream().map(UserResponse.UserProfileAndActivity::from).toList();
     }
   }
 
   public record UserActivityDetail(long activityId, int generation, String part, String team) {
-    public static UserActivityDetail from(
-        GetUserInformationUsecase.UserActivityinfo userActivityInfo) {
+    public static UserActivityDetail from(GetUserProfileUsecase.UserActivityinfo userActivityInfo) {
       return new UserActivityDetail(
           userActivityInfo.activityId(),
           userActivityInfo.generation(),

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
@@ -2,6 +2,7 @@ package sopt.makers.authentication.database.rdb.repository.user;
 
 import sopt.makers.authentication.database.rdb.entity.UserEntity;
 import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.usecase.user.port.out.UserRepository;
 
@@ -46,6 +47,14 @@ public class UserRepositoryImpl implements UserRepository {
   @Override
   public void update(User user, SocialAccount socialAccount) {
     User updatedUser = user.updateSocialAccount(socialAccount);
+    UserEntity userEntity = UserEntity.fromDomain(updatedUser);
+    userRegister.save(userEntity);
+  }
+
+  @Transactional
+  @Override
+  public void update(User user, Profile profile) {
+    User updatedUser = user.updateProfile(profile);
     UserEntity userEntity = UserEntity.fromDomain(updatedUser);
     userRegister.save(userEntity);
   }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
@@ -26,6 +26,11 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
+  public User findById(Long userId) {
+    return userRetriever.findById(userId).toDomain();
+  }
+
+  @Override
   public List<User> findAllById(List<Long> userIds) {
     return userRetriever.findAllById(userIds);
   }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
@@ -35,6 +35,10 @@ public class UserRetriever {
     return userEntity.toDomain();
   }
 
+  public UserEntity findById(Long userId) {
+    return userJpaRepository.findById(userId).orElseThrow(() -> new UserException(NOT_FOUND_USER));
+  }
+
   public List<User> findAllById(List<Long> userIds) {
     List<UserEntity> userEntityList = userJpaRepository.findAllWithActivityHistoriesByIdIn(userIds);
     return userEntityList.stream().map(UserEntity::toDomain).toList();

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRegister.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRegister.java
@@ -2,6 +2,8 @@ package sopt.makers.authentication.database.rdb.repository.user.activity;
 
 import sopt.makers.authentication.database.rdb.entity.UserActivityHistoryEntity;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -14,5 +16,9 @@ public class UserActivityHistoryRegister {
 
   public void save(UserActivityHistoryEntity userActivityHistoryEntity) {
     userActivityHistoryJpaRepository.save(userActivityHistoryEntity);
+  }
+
+  public void saveAll(List<UserActivityHistoryEntity> userActivityHistoryEntities) {
+    userActivityHistoryJpaRepository.saveAll(userActivityHistoryEntities);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/activity/UserActivityHistoryRepositoryImpl.java
@@ -6,6 +6,8 @@ import sopt.makers.authentication.domain.user.ActivityList;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,5 +31,15 @@ public class UserActivityHistoryRepositoryImpl implements UserActivityHistoryRep
 
   public ActivityList findByUser(Long userId) {
     return userActivityHistoryRetriever.findByUser(userId);
+  }
+
+  @Transactional
+  @Override
+  public void update(User user, ActivityList activityList) {
+    List<UserActivityHistoryEntity> userActivityHistoryEntities =
+        activityList.getActivities().stream()
+            .map(activity -> UserActivityHistoryEntity.fromDomain(user, activity))
+            .toList();
+    userActivityHistoryRegister.saveAll(userActivityHistoryEntities);
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/Part.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Part.java
@@ -22,12 +22,9 @@ public enum Part {
   private final String name;
 
   public static Part findPart(final String part) {
-    if (part != null) {
-      return Arrays.stream(Part.values())
-          .filter(p -> p.name.equals(part))
-          .findFirst()
-          .orElseThrow(() -> new UserException(NOT_FOUND_PART));
-    }
-    return null;
+    return Arrays.stream(Part.values())
+        .filter(p -> p.name.equals(part))
+        .findFirst()
+        .orElseThrow(() -> new UserException(NOT_FOUND_PART));
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/Part.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Part.java
@@ -22,10 +22,12 @@ public enum Part {
   private final String name;
 
   public static Part findPart(final String part) {
-
-    return Arrays.stream(Part.values())
-        .filter(p -> p.name().equals(part))
-        .findFirst()
-        .orElseThrow(() -> new UserException(NOT_FOUND_PART));
+    if (part != null) {
+      return Arrays.stream(Part.values())
+          .filter(p -> p.name.equals(part))
+          .findFirst()
+          .orElseThrow(() -> new UserException(NOT_FOUND_PART));
+    }
+    return null;
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Profile.java
@@ -16,6 +16,12 @@ public record Profile(
     return new Profile(name, Optional.ofNullable(email), phone, birthday, Optional.empty());
   }
 
+  public Profile updateProfile(
+      String email, String phone, LocalDate birthday, String profileImage) {
+    return new Profile(
+        this.name, Optional.ofNullable(email), phone, birthday, Optional.ofNullable(profileImage));
+  }
+
   public Profile updateName(final String name) {
     return new Profile(name, this.email, this.phone, this.birthday, this.profileImage);
   }

--- a/src/main/java/sopt/makers/authentication/domain/user/Team.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Team.java
@@ -19,12 +19,9 @@ public enum Team {
   private final String name;
 
   public static Team findTeam(final String team) {
-    if (team != null) {
-      return Arrays.stream(Team.values())
-          .filter(p -> p.name.equals(team))
-          .findFirst()
-          .orElseThrow(() -> new UserException(NOT_FOUND_TEAM));
-    }
-    return null;
+    return Arrays.stream(Team.values())
+        .filter(p -> p.name.equals(team))
+        .findFirst()
+        .orElseThrow(() -> new UserException(NOT_FOUND_TEAM));
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/Team.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Team.java
@@ -1,5 +1,11 @@
 package sopt.makers.authentication.domain.user;
 
+import static sopt.makers.authentication.support.code.domain.failure.UserFailure.NOT_FOUND_TEAM;
+
+import sopt.makers.authentication.support.exception.domain.UserException;
+
+import java.util.Arrays;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +17,14 @@ public enum Team {
   OPERATION("운영팀");
 
   private final String name;
+
+  public static Team findTeam(final String team) {
+    if (team != null) {
+      return Arrays.stream(Team.values())
+          .filter(p -> p.name.equals(team))
+          .findFirst()
+          .orElseThrow(() -> new UserException(NOT_FOUND_TEAM));
+    }
+    return null;
+  }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/User.java
@@ -56,6 +56,10 @@ public class User {
         .build();
   }
 
+  public User updateProfile(final Profile profile) {
+    return User.createUser(this.id, socialAccount, profile);
+  }
+
   public void joinActivity(final Activity activity) {
     this.activities = activities.addActivity(activity);
   }

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/UserFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/UserFailure.java
@@ -19,7 +19,10 @@ public enum UserFailure implements FailureCode {
   // 404
   NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다"),
   NOT_FOUND_PART(HttpStatus.NOT_FOUND, "존재하지 않는 파트입니다"),
-  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
+  NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "존재하지 않는 팀입니다"),
+  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+  NOT_FOUND_USER_ACTIVITY(HttpStatus.NOT_FOUND, "유저가 활동한 기수가 아닙니다.");
+
   private final HttpStatus status;
   private final String message;
 }

--- a/src/main/java/sopt/makers/authentication/support/code/domain/success/UserSuccess.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/success/UserSuccess.java
@@ -12,7 +12,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
 public enum UserSuccess implements SuccessCode {
-  GET_USER_INFORMATION(HttpStatus.OK, "유저 기본 정보 조회에 성공했습니다.");
+  GET_USER_PROFILE(HttpStatus.OK, "유저 기본 정보 조회에 성공했습니다."),
+  UPDATE_USER_PROFILE(HttpStatus.OK, "유저 기본 정보 수정에 성공했습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/sopt/makers/authentication/support/validator/UserIdValidator.java
+++ b/src/main/java/sopt/makers/authentication/support/validator/UserIdValidator.java
@@ -16,4 +16,10 @@ public class UserIdValidator {
       throw new UserException(NOT_VALID_USER_ID);
     }
   }
+
+  public void validateUserIds(Long userId) {
+    if (userId <= 0) {
+      throw new UserException(NOT_VALID_USER_ID);
+    }
+  }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
@@ -7,7 +7,7 @@ import sopt.makers.authentication.domain.user.User;
 
 import java.util.List;
 
-public interface GetUserInformationUsecase {
+public interface GetUserProfileUsecase {
 
   List<UserProfileAndActivityInfo> getUserInformation(List<Long> userIds);
 

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/UpdateUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/UpdateUserProfileUsecase.java
@@ -1,0 +1,31 @@
+package sopt.makers.authentication.usecase.user.port.in;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface UpdateUserProfileUsecase {
+  void updateUserProfile(UserProfileCommand userProfileCommand);
+
+  record UserProfileCommand(
+      String profileImage,
+      LocalDate birthday,
+      String phone,
+      String email,
+      List<SoptActivityCommand> soptActivities) {
+    public static UserProfileCommand of(
+        String profileImage,
+        LocalDate birthday,
+        String phone,
+        String email,
+        List<SoptActivityCommand> soptActivities) {
+      return new UserProfileCommand(profileImage, birthday, phone, email, soptActivities);
+    }
+  }
+
+  record SoptActivityCommand(Long activityId, int generation, String part, String team) {
+    public static SoptActivityCommand of(
+        Long activityId, int generation, String part, String team) {
+      return new SoptActivityCommand(activityId, generation, part, team);
+    }
+  }
+}

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/UpdateUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/UpdateUserProfileUsecase.java
@@ -7,25 +7,26 @@ public interface UpdateUserProfileUsecase {
   void updateUserProfile(UserProfileCommand userProfileCommand);
 
   record UserProfileCommand(
+      Long userId,
       String profileImage,
       LocalDate birthday,
       String phone,
       String email,
       List<SoptActivityCommand> soptActivities) {
     public static UserProfileCommand of(
+        Long userId,
         String profileImage,
         LocalDate birthday,
         String phone,
         String email,
         List<SoptActivityCommand> soptActivities) {
-      return new UserProfileCommand(profileImage, birthday, phone, email, soptActivities);
+      return new UserProfileCommand(userId, profileImage, birthday, phone, email, soptActivities);
     }
   }
 
-  record SoptActivityCommand(Long activityId, int generation, String part, String team) {
-    public static SoptActivityCommand of(
-        Long activityId, int generation, String part, String team) {
-      return new SoptActivityCommand(activityId, generation, part, team);
+  record SoptActivityCommand(Long activityId, String team) {
+    public static SoptActivityCommand of(Long activityId, String team) {
+      return new SoptActivityCommand(activityId, team);
     }
   }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserActivityHistoryRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserActivityHistoryRepository.java
@@ -8,4 +8,6 @@ public interface UserActivityHistoryRepository {
   void save(User user, Activity activity);
 
   ActivityList findByUser(Long userId);
+
+  void update(User user, ActivityList activityList);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
@@ -10,6 +10,8 @@ public interface UserRepository {
 
   User findBySocialAccount(SocialAccount socialAccount);
 
+  User findById(Long userId);
+
   User findByPhone(String phone);
 
   List<User> findAllById(List<Long> userIds);

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.usecase.user.port.out;
 
 import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 
 import java.util.List;
@@ -16,6 +17,8 @@ public interface UserRepository {
   User save(User user);
 
   void update(User user, SocialAccount socialAccount);
+
+  void update(User user, Profile profile);
 
   boolean existsByPhone(String phone);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/GetUserProfileService.java
@@ -1,7 +1,7 @@
 package sopt.makers.authentication.usecase.user.service;
 
 import sopt.makers.authentication.domain.user.User;
-import sopt.makers.authentication.usecase.user.port.in.GetUserInformationUsecase;
+import sopt.makers.authentication.usecase.user.port.in.GetUserProfileUsecase;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserRepository;
 
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class GetUserInformationService implements GetUserInformationUsecase {
+public class GetUserProfileService implements GetUserProfileUsecase {
 
   private final UserRepository userRepository;
   private final UserActivityHistoryRepository userActivityHistoryRepository;

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileService.java
@@ -1,0 +1,71 @@
+package sopt.makers.authentication.usecase.user.service;
+
+import static sopt.makers.authentication.support.code.domain.failure.UserFailure.NOT_FOUND_USER_ACTIVITY;
+
+import sopt.makers.authentication.domain.user.Activity;
+import sopt.makers.authentication.domain.user.ActivityList;
+import sopt.makers.authentication.domain.user.Profile;
+import sopt.makers.authentication.domain.user.Team;
+import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.support.exception.domain.UserException;
+import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase;
+import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
+import sopt.makers.authentication.usecase.user.port.out.UserRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserProfileService implements UpdateUserProfileUsecase {
+  private final UserRepository userRepository;
+  private final UserActivityHistoryRepository userActivityHistoryRepository;
+
+  @Transactional
+  @Override
+  public void updateUserProfile(UserProfileCommand command) {
+    User user = userRepository.findByPhone(command.phone());
+    ActivityList activityList = userActivityHistoryRepository.findByUser(user.getId());
+    Profile updatedProfile =
+        user.getProfile()
+            .updateProfile(
+                command.email(), command.phone(),
+                command.birthday(), command.profileImage());
+    Map<Long, Activity> existingActivitiesById = findExistsActivities(activityList);
+    List<Activity> updatedActivities = updateActivities(command, existingActivitiesById);
+
+    userActivityHistoryRepository.update(user, ActivityList.of(updatedActivities));
+    userRepository.update(user, updatedProfile);
+  }
+
+  private Map<Long, Activity> findExistsActivities(ActivityList activityList) {
+    return activityList.getActivities().stream()
+        .collect(Collectors.toMap(Activity::getId, Function.identity()));
+  }
+
+  private List<Activity> updateActivities(
+      UserProfileCommand command, Map<Long, Activity> existingActivitiesById) {
+    return command.soptActivities().stream()
+        .map(
+            c -> {
+              Activity existing = existingActivitiesById.get(c.activityId());
+              if (existing == null) {
+                throw new UserException(NOT_FOUND_USER_ACTIVITY);
+              }
+              return Activity.of(
+                  c.activityId(),
+                  existing.getGeneration(),
+                  Team.findTeam(c.team()),
+                  existing.getPart(),
+                  existing.getRole());
+            })
+        .toList();
+  }
+}

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileService.java
@@ -31,7 +31,7 @@ public class UpdateUserProfileService implements UpdateUserProfileUsecase {
   @Transactional
   @Override
   public void updateUserProfile(UserProfileCommand command) {
-    User user = userRepository.findByPhone(command.phone());
+    User user = userRepository.findById(command.userId());
     ActivityList activityList = userActivityHistoryRepository.findByUser(user.getId());
     Profile updatedProfile =
         user.getProfile()
@@ -62,7 +62,7 @@ public class UpdateUserProfileService implements UpdateUserProfileUsecase {
               return Activity.of(
                   c.activityId(),
                   existing.getGeneration(),
-                  Team.findTeam(c.team()),
+                  c.team() == null ? null : Team.findTeam(c.team()),
                   existing.getPart(),
                   existing.getRole());
             })

--- a/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
@@ -1,0 +1,82 @@
+package sopt.makers.authentication.usecase.user.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import sopt.makers.authentication.domain.user.Activity;
+import sopt.makers.authentication.domain.user.ActivityList;
+import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.domain.user.Profile;
+import sopt.makers.authentication.domain.user.Role;
+import sopt.makers.authentication.domain.user.Team;
+import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase.SoptActivityCommand;
+import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase.UserProfileCommand;
+import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
+import sopt.makers.authentication.usecase.user.port.out.UserRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class UpdateUserProfileServiceTest {
+
+  @InjectMocks private UpdateUserProfileService updateUserProfileService;
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private UserActivityHistoryRepository userActivityHistoryRepository;
+
+  private final String phone = "01012345678";
+  private final String email = "test@example.com";
+  private final String profileImage = "image.png";
+  private final LocalDate birthday = LocalDate.of(2000, 1, 1);
+
+  private User mockedUser;
+  private Profile originalProfile;
+  private Profile updatedProfile;
+
+  @BeforeEach
+  void setUpMocks() {
+    mockedUser = mock(User.class);
+    originalProfile = mock(Profile.class);
+    updatedProfile = mock(Profile.class);
+
+    when(mockedUser.getId()).thenReturn(1L);
+    when(mockedUser.getProfile()).thenReturn(originalProfile);
+    when(originalProfile.updateProfile(email, phone, birthday, profileImage))
+        .thenReturn(updatedProfile);
+    when(userRepository.findByPhone(phone)).thenReturn(mockedUser);
+  }
+
+  @Test
+  @DisplayName("유저 프로필(프로필 이미지, 번호, 이메일, 생년월일) 및 활동 정보가 정상적으로 수정된다.")
+  void 유저_프로필_및_활동_정보_수정시_정상적으로_수정이_완료된다() {
+    // given
+    Activity existingActivity = Activity.of(1L, 33, Team.MEDIA, Part.SERVER, Role.MEMBER);
+    ActivityList activityList = ActivityList.of(List.of(existingActivity));
+    when(userActivityHistoryRepository.findByUser(1L)).thenReturn(activityList);
+
+    SoptActivityCommand activityCommand = SoptActivityCommand.of(1L, 33, "서버", "미디어팀");
+    UserProfileCommand userProfileCommand =
+        UserProfileCommand.of(profileImage, birthday, phone, email, List.of(activityCommand));
+
+    // when
+    updateUserProfileService.updateUserProfile(userProfileCommand);
+
+    // then
+    verify(userRepository).update(mockedUser, updatedProfile);
+    verify(userActivityHistoryRepository, times(1)).update(eq(mockedUser), any(ActivityList.class));
+  }
+}

--- a/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
@@ -57,7 +57,7 @@ class UpdateUserProfileServiceTest {
     when(mockedUser.getProfile()).thenReturn(originalProfile);
     when(originalProfile.updateProfile(email, phone, birthday, profileImage))
         .thenReturn(updatedProfile);
-    when(userRepository.findByPhone(phone)).thenReturn(mockedUser);
+    when(userRepository.findById(1L)).thenReturn(mockedUser);
   }
 
   @Test
@@ -68,9 +68,9 @@ class UpdateUserProfileServiceTest {
     ActivityList activityList = ActivityList.of(List.of(existingActivity));
     when(userActivityHistoryRepository.findByUser(1L)).thenReturn(activityList);
 
-    SoptActivityCommand activityCommand = SoptActivityCommand.of(1L, 33, "서버", "미디어팀");
+    SoptActivityCommand activityCommand = SoptActivityCommand.of(1L, "미디어팀");
     UserProfileCommand userProfileCommand =
-        UserProfileCommand.of(profileImage, birthday, phone, email, List.of(activityCommand));
+        UserProfileCommand.of(1L, profileImage, birthday, phone, email, List.of(activityCommand));
 
     // when
     updateUserProfileService.updateUserProfile(userProfileCommand);


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #80 

## Work Description ✏️
- 유저 정보 수정 API 구현했습니다!

- 수정시에 db에 레코드를 삭제하고, 새로운 레코드를 저장하는 방식으로 구현할까 하다가, save()를 호출해서 기존의 레코드를 update하는 방식으로 구현했어요! (유저 정보 수정시에 기수정보를 새로 만들거나 하는것이 아닌 기존의 데이터를 수정하는 것이라 생각해서 이렇게 했습니다!)

- PR보다 제가 직접 설명이 필요한 부분은 comment를 다는 게 더 이해하시기 편할 것 같아서 comment 달아둘게요!!
<img width="979" alt="스크린샷 2025-05-13 오후 4 43 31" src="https://github.com/user-attachments/assets/9be7ecbe-046b-494a-9476-d9f4a4244fa1" />


## PR Point 📸
뭐든 아무거나 피드백 대환영 ㅎㅎ