### PR TITLE
[FIX/#98] 유저 정보 조회 response에 latestGeneration 포함하도록 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
@@ -17,6 +17,7 @@ public final class UserResponse {
       String birthday,
       String phone,
       String email,
+      Integer latestGeneration,
       List<UserActivityDetail> soptActivities) {
     public static UserProfileAndActivity from(
         GetUserProfileUsecase.UserProfileAndActivityInfo userProfileAndActivityInfo) {
@@ -32,6 +33,7 @@ public final class UserResponse {
           userProfileAndActivityInfo.birthday(),
           userProfileAndActivityInfo.phone(),
           userProfileAndActivityInfo.email(),
+          userProfileAndActivityInfo.latestGeneration(),
           soptActivities);
     }
 

--- a/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
@@ -17,7 +17,7 @@ public final class UserResponse {
       String birthday,
       String phone,
       String email,
-      Integer latestGeneration,
+      Integer lastGeneration,
       List<UserActivityDetail> soptActivities) {
     public static UserProfileAndActivity from(
         GetUserProfileUsecase.UserProfileAndActivityInfo userProfileAndActivityInfo) {
@@ -33,7 +33,7 @@ public final class UserResponse {
           userProfileAndActivityInfo.birthday(),
           userProfileAndActivityInfo.phone(),
           userProfileAndActivityInfo.email(),
-          userProfileAndActivityInfo.latestGeneration(),
+          userProfileAndActivityInfo.lastGeneration(),
           soptActivities);
     }
 

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
@@ -18,6 +18,7 @@ public interface GetUserProfileUsecase {
       String birthday,
       String phone,
       String email,
+      Integer latestGeneration,
       List<UserActivityinfo> soptActivities) {
 
     public static UserProfileAndActivityInfo of(User user, ActivityList activities) {
@@ -32,6 +33,7 @@ public interface GetUserProfileUsecase {
           profile.birthday().toString(),
           profile.phone(),
           profile.email().orElse(null),
+          activities.getLastActivity().getGeneration(),
           userActivityinfos);
     }
   }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
@@ -18,7 +18,7 @@ public interface GetUserProfileUsecase {
       String birthday,
       String phone,
       String email,
-      Integer latestGeneration,
+      Integer lastGeneration,
       List<UserActivityinfo> soptActivities) {
 
     public static UserProfileAndActivityInfo of(User user, ActivityList activities) {


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #98 

## Work Description ✏️
- 앱팀에서 유저 정보 조회시에 latestGeneration이 필요하다고 하셔서 response dto 필드에 추가했습니다!
- 변경 사항은 매우 적어요 ㅎㅎ
<img width="991" alt="스크린샷 2025-05-25 오후 9 02 20" src="https://github.com/user-attachments/assets/32042378-505e-49b9-931b-0f354d418a97" />

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
