### PR TITLE
[FEAT/#100] 번호 인증 여부 검사를 위한 validator 클래스 구현

### DIFF
--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationJpaRepository.java
@@ -14,4 +14,7 @@ interface PhoneVerificationJpaRepository extends JpaRepository<PhoneVerification
 
   void deleteByNameAndPhoneAndCodeAndType(
       String name, String phone, String code, PhoneVerificationType type);
+
+  Optional<PhoneVerificationEntity> findTopByPhoneAndTypeAndNameOrderByCreatedAtDesc(
+      String phone, PhoneVerificationType type, String name);
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationRepositoryImpl.java
@@ -31,6 +31,13 @@ public class PhoneVerificationRepositoryImpl implements PhoneVerificationReposit
     return phoneVerificationEntity.toDomain();
   }
 
+  @Override
+  public PhoneVerification findLatestByPhoneNameType(PhoneVerification phoneVerification) {
+    PhoneVerificationEntity phoneVerificationEntity =
+        retriever.findLatestByPhoneNameType(phoneVerification);
+    return phoneVerificationEntity.toDomain();
+  }
+
   @Transactional
   @Override
   public void deleteByPhoneVerification(PhoneVerification phoneVerification) {

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/phone/verification/PhoneVerificationRetriever.java
@@ -21,4 +21,13 @@ public class PhoneVerificationRetriever {
             phoneVerification.getPhone(), phoneVerification.getVerificationType())
         .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_PHONE_VERIFICATION));
   }
+
+  public PhoneVerificationEntity findLatestByPhoneNameType(PhoneVerification phoneVerification) {
+    return jpaRepository
+        .findTopByPhoneAndTypeAndNameOrderByCreatedAtDesc(
+            phoneVerification.getPhone(),
+            phoneVerification.getVerificationType(),
+            phoneVerification.getName())
+        .orElseThrow(() -> new AuthException(AuthFailure.NOT_FOUND_PHONE_VERIFICATION));
+  }
 }

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
@@ -22,6 +22,9 @@ public enum AuthFailure implements FailureCode {
   // 401
   INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "API 키가 유효하지 않습니다"),
 
+  // 403
+  PHONE_NOT_VERIFIED(HttpStatus.FORBIDDEN, "번호 인증이 되지 않은 번호입니다."),
+
   // 404
   NOT_FOUND_PHONE_VERIFICATION(HttpStatus.NOT_FOUND, "존재하지 않는 번호 인증 이력입니다."),
   NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 계정 정보와 일치하는 회원이 없습니다"),

--- a/src/main/java/sopt/makers/authentication/support/validator/PhoneVerificationValidator.java
+++ b/src/main/java/sopt/makers/authentication/support/validator/PhoneVerificationValidator.java
@@ -1,0 +1,31 @@
+package sopt.makers.authentication.support.validator;
+
+import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.PHONE_NOT_VERIFIED;
+
+import sopt.makers.authentication.domain.auth.PhoneVerification;
+import sopt.makers.authentication.domain.auth.PhoneVerificationType;
+import sopt.makers.authentication.support.exception.domain.AuthException;
+import sopt.makers.authentication.usecase.auth.port.out.PhoneVerificationRepository;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PhoneVerificationValidator {
+  private final PhoneVerificationRepository phoneVerificationRepository;
+
+  public void validate(String name, String phone, PhoneVerificationType type) {
+    boolean isVerified = findPhoneVerification(name, phone, type).isVerified();
+    if (!isVerified) {
+      throw new AuthException(PHONE_NOT_VERIFIED);
+    }
+  }
+
+  private PhoneVerification findPhoneVerification(
+      String name, String phone, PhoneVerificationType type) {
+    PhoneVerification phoneVerification = PhoneVerification.of(name, phone, type, null);
+    return phoneVerificationRepository.findLatestByPhoneNameType(phoneVerification);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/usecase/auth/port/out/PhoneVerificationRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/port/out/PhoneVerificationRepository.java
@@ -8,6 +8,8 @@ public interface PhoneVerificationRepository {
 
   PhoneVerification findByPhoneVerification(PhoneVerification phoneVerification);
 
+  PhoneVerification findLatestByPhoneNameType(PhoneVerification phoneVerification);
+
   void deleteByPhoneVerification(PhoneVerification phoneVerification);
 
   void update(PhoneVerification phoneVerification);

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/SignUpService.java
@@ -3,12 +3,14 @@ package sopt.makers.authentication.usecase.auth.service;
 import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.NOT_FOUND_REGISTER_INFO;
 
 import sopt.makers.authentication.domain.auth.AuthPlatform;
+import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 import sopt.makers.authentication.support.exception.domain.AuthException;
+import sopt.makers.authentication.support.validator.PhoneVerificationValidator;
 import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
@@ -24,21 +26,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SignUpService implements SignUpUsecase {
   private final OAuthAuthenticator oAuthAuthenticator;
-
   private final UserRepository userRepository;
   private final UserRegisterInfoRepository userRegisterInfoRepository;
   private final UserActivityHistoryRepository userActivityHistoryRepository;
+  private final PhoneVerificationValidator phoneVerificationValidator;
 
   @Transactional
   @Override
   public void signUp(SignUpCommand command) {
+    phoneVerificationValidator.validate(
+        command.name(), command.phone(), PhoneVerificationType.REGISTER);
     String authPlatformId =
         oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     UserRegisterInfo targetRegisterInfo =
         userRegisterInfoRepository
             .findByPhone(command.phone())
             .orElseThrow(() -> new AuthException(NOT_FOUND_REGISTER_INFO));
-
     SocialAccount socialAccount = createSocialAccount(authPlatformId, command.authPlatform());
     Profile profile = createProfile(targetRegisterInfo);
     Activity activity = createActivity(targetRegisterInfo);

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/UpdateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/UpdateSocialAccountService.java
@@ -1,7 +1,9 @@
 package sopt.makers.authentication.usecase.auth.service;
 
+import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.support.validator.PhoneVerificationValidator;
 import sopt.makers.authentication.usecase.auth.port.in.UpdateSocialAccountUsecase;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 import sopt.makers.authentication.usecase.user.port.out.UserRepository;
@@ -15,10 +17,13 @@ import lombok.RequiredArgsConstructor;
 public class UpdateSocialAccountService implements UpdateSocialAccountUsecase {
   private final UserRepository userRepository;
   private final OAuthAuthenticator oAuthAuthenticator;
+  private final PhoneVerificationValidator phoneVerificationValidator;
 
   @Override
   public boolean update(UpdateSocialAccountCommand command) {
     User user = userRepository.findByPhone(command.phone());
+    phoneVerificationValidator.validate(
+        user.getProfile().name(), command.phone(), PhoneVerificationType.CHANGE_SOCIAL_PLATFORM);
     String authPlatformId =
         oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     SocialAccount updatedSocialAccount = SocialAccount.of(authPlatformId, command.authPlatform());

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/GetSocialAccountPlatformService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/GetSocialAccountPlatformService.java
@@ -1,7 +1,9 @@
 package sopt.makers.authentication.usecase.user.service;
 
 import sopt.makers.authentication.domain.auth.AuthPlatform;
+import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.support.validator.PhoneVerificationValidator;
 import sopt.makers.authentication.usecase.auth.port.in.GetSocialAccountUsecase;
 import sopt.makers.authentication.usecase.user.port.out.UserRepository;
 
@@ -13,11 +15,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GetSocialAccountPlatformService implements GetSocialAccountUsecase {
   private final UserRepository userRepository;
+  private final PhoneVerificationValidator phoneVerificationValidator;
 
   @Override
   public SocialAccountPlatformInfo getSocialAccountPlatform(
       GetSocialAccountPlatformCommand command) {
     User user = userRepository.findByPhone(command.phone());
+    phoneVerificationValidator.validate(
+        user.getProfile().name(), command.phone(), PhoneVerificationType.SEARCH_SOCIAL_PLATFORM);
     AuthPlatform authPlatform = user.getSocialAccount().authPlatformType();
     return new SocialAccountPlatformInfo(authPlatform.name());
   }

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileService.java
@@ -2,12 +2,14 @@ package sopt.makers.authentication.usecase.user.service;
 
 import static sopt.makers.authentication.support.code.domain.failure.UserFailure.NOT_FOUND_USER_ACTIVITY;
 
+import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.ActivityList;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.support.exception.domain.UserException;
+import sopt.makers.authentication.support.validator.PhoneVerificationValidator;
 import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserRepository;
@@ -27,11 +29,14 @@ import lombok.RequiredArgsConstructor;
 public class UpdateUserProfileService implements UpdateUserProfileUsecase {
   private final UserRepository userRepository;
   private final UserActivityHistoryRepository userActivityHistoryRepository;
+  private final PhoneVerificationValidator phoneVerificationValidator;
 
   @Transactional
   @Override
   public void updateUserProfile(UserProfileCommand command) {
     User user = userRepository.findById(command.userId());
+    phoneVerificationValidator.validate(
+        user.getProfile().name(), command.phone(), PhoneVerificationType.CHANGE_PHONE_NUMBER);
     ActivityList activityList = userActivityHistoryRepository.findByUser(user.getId());
     Profile updatedProfile =
         user.getProfile()

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileService.java
@@ -35,8 +35,10 @@ public class UpdateUserProfileService implements UpdateUserProfileUsecase {
   @Override
   public void updateUserProfile(UserProfileCommand command) {
     User user = userRepository.findById(command.userId());
-    phoneVerificationValidator.validate(
-        user.getProfile().name(), command.phone(), PhoneVerificationType.CHANGE_PHONE_NUMBER);
+    if (!user.getProfile().phone().equals(command.phone())) {
+      phoneVerificationValidator.validate(
+          user.getProfile().name(), command.phone(), PhoneVerificationType.CHANGE_PHONE_NUMBER);
+    }
     ActivityList activityList = userActivityHistoryRepository.findByUser(user.getId());
     Profile updatedProfile =
         user.getProfile()

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/GetSocialAccountPlatformServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/GetSocialAccountPlatformServiceTest.java
@@ -1,13 +1,19 @@
 package sopt.makers.authentication.usecase.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import sopt.makers.authentication.domain.auth.AuthPlatform;
+import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.support.validator.PhoneVerificationValidator;
 import sopt.makers.authentication.usecase.auth.port.in.GetSocialAccountUsecase;
 import sopt.makers.authentication.usecase.user.port.out.UserRepository;
 import sopt.makers.authentication.usecase.user.service.GetSocialAccountPlatformService;
@@ -37,12 +43,16 @@ class GetSocialAccountPlatformServiceTest {
 
   @MockBean UserRepository userRepository;
 
+  @MockBean PhoneVerificationValidator phoneVerificationValidator;
+
   @Autowired GetSocialAccountPlatformService getSocialAccountPlatformService;
 
   @BeforeEach
   void setMockUser() {
     User mockedUserForGoogle = mock(User.class);
     User mockedUserForApple = mock(User.class);
+    Profile mockProfile = mock(Profile.class);
+
     SocialAccount mockedSocialAccountForGoogle = mock(SocialAccount.class);
     SocialAccount mockedSocialAccountForApple = mock(SocialAccount.class);
 
@@ -51,11 +61,26 @@ class GetSocialAccountPlatformServiceTest {
     given(mockedSocialAccountForGoogle.authPlatformType()).willReturn(AuthPlatform.GOOGLE);
     given(mockedSocialAccountForApple.authPlatformType()).willReturn(AuthPlatform.APPLE);
 
+    given(mockedUserForGoogle.getProfile()).willReturn(mockProfile);
     given(mockedUserForGoogle.getSocialAccount()).willReturn(mockedSocialAccountForGoogle);
     given(mockedUserForApple.getSocialAccount()).willReturn(mockedSocialAccountForApple);
+    given(mockedUserForApple.getProfile()).willReturn(mockProfile);
 
     when(userRepository.findByPhone(TEST_USER_PHONE_FOR_GOOGLE)).thenReturn(mockedUserForGoogle);
     when(userRepository.findByPhone(TEST_USER_PHONE_FOR_APPLE)).thenReturn(mockedUserForApple);
+
+    doNothing()
+        .when(phoneVerificationValidator)
+        .validate(
+            anyString(),
+            eq(TEST_USER_PHONE_FOR_GOOGLE),
+            eq(PhoneVerificationType.SEARCH_SOCIAL_PLATFORM));
+    doNothing()
+        .when(phoneVerificationValidator)
+        .validate(
+            anyString(),
+            eq(TEST_USER_PHONE_FOR_APPLE),
+            eq(PhoneVerificationType.SEARCH_SOCIAL_PLATFORM));
   }
 
   @ParameterizedTest(name = "({index}) command : {0} -> result : {1}")
@@ -77,11 +102,11 @@ class GetSocialAccountPlatformServiceTest {
     return Stream.of(
         Arguments.of(
             new GetSocialAccountUsecase.GetSocialAccountPlatformCommand(
-                null, TEST_USER_PHONE_FOR_GOOGLE),
+                "", TEST_USER_PHONE_FOR_GOOGLE),
             PLATFORM_NAME_GOOGLE),
         Arguments.of(
             new GetSocialAccountUsecase.GetSocialAccountPlatformCommand(
-                null, TEST_USER_PHONE_FOR_APPLE),
+                "", TEST_USER_PHONE_FOR_APPLE),
             PLATFORM_NAME_APPLE));
   }
 }

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/SignUpServiceTest.java
@@ -11,6 +11,7 @@ import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
+import sopt.makers.authentication.support.validator.PhoneVerificationValidator;
 import sopt.makers.authentication.usecase.auth.port.in.SignUpUsecase.SignUpCommand;
 import sopt.makers.authentication.usecase.auth.port.out.OAuthAuthenticator;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
@@ -35,13 +36,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 @TestPropertySource(locations = {"classpath:env/test.env"})
 @ExtendWith(MockitoExtension.class)
 class SignUpServiceTest {
-
   @InjectMocks private SignUpService signUpService;
   @Mock private OAuthAuthenticator oAuthAuthenticator;
   @Mock private UserRegisterInfoRepository userRegisterInfoRepository;
   @Mock private UserRepository userRepository;
   @Mock private UserActivityHistoryRepository userActivityHistoryRepository;
   @Mock private UserRegisterInfo userRegisterInfo;
+  @Mock private PhoneVerificationValidator phoneVerificationValidator;
 
   private final String TEST_TOKEN = "dummy-token";
   private final String TEST_PHONE = "01012345678";

--- a/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
@@ -2,7 +2,10 @@ package sopt.makers.authentication.usecase.user.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.ActivityList;
@@ -11,6 +14,7 @@ import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.Role;
 import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.support.validator.PhoneVerificationValidator;
 import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase.SoptActivityCommand;
 import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase.UserProfileCommand;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
@@ -31,12 +35,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class UpdateUserProfileServiceTest {
-
   @InjectMocks private UpdateUserProfileService updateUserProfileService;
-
   @Mock private UserRepository userRepository;
-
   @Mock private UserActivityHistoryRepository userActivityHistoryRepository;
+  @Mock private PhoneVerificationValidator phoneVerificationValidator;
 
   private final String phone = "01012345678";
   private final String email = "test@example.com";

--- a/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
@@ -55,6 +55,7 @@ class UpdateUserProfileServiceTest {
     originalProfile = mock(Profile.class);
     updatedProfile = mock(Profile.class);
 
+    when(originalProfile.phone()).thenReturn(phone);
     when(mockedUser.getId()).thenReturn(1L);
     when(mockedUser.getProfile()).thenReturn(originalProfile);
     when(originalProfile.updateProfile(email, phone, birthday, profileImage))


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #100 

## Work Description ✏️
- 번호 인증 여부 검사를 위한 validator 클래스를 구현했어요.
- 번호 인증 여부를 검사하는 API는 다음과 같아요. (소셜 계정 조회/변경 + 회원가입 + 유저 정보 수정) - > 혹시나 빠트린 부분이 있다면 말씀해주세요!

구현할 때 아래와 같은 고민이 있었는데, 다들 어떻게 생각하는지 궁금해요👀

### ⚡️ PhoneVerificationValidator 클래스의 책임을 어디까지 가져갈지
1. 해당 클래스가 번호 인증 여부만 확인하는 책임을 가진다.
처음에는 이렇게 검증만 하려고 했는데, 이렇게 되면 각 사용처마다 DB 조회와 도메인 객체를 생성하는 로직이 반복적으로 사용되기도 하고, 번호 인증 여부의 책임에 DB 조회와 도메인 객체를 생성하는 일련의 과정이 포함이 되게 되는 구조라고 생각해서 2번과 같은 방향으로 구현했습니다!

```java
  public void validate(PhoneVerification phoneVerification) {
    boolean isVerified = phoneVerification.isVerified();
    if (!isVerified) {
      throw new AuthException(PHONE_NOT_VERIFIED);
    }
  }

```
<br/>

2. PhoneVerfication 도메인 객체 생성 + DB에서 번호인증내역 조회 + 인증 여부 검증
https://github.com/sopt-makers/sopt-auth-backend/blob/0566a86d5e184a87bca1b345d4880ce751bac1f6/src/main/java/sopt/makers/authentication/support/validator/PhoneVerificationValidator.java#L14-L31

<br/>

<img width="648" alt="image" src="https://github.com/user-attachments/assets/e69e5b1e-9553-4514-a16d-0364fcee7d7a" />



## PR Point 📸
스프링 AOP + 커스텀 어노테이션으로 구현할 수도 있을 것 같은데, 각 API마다 name과 phone을 parameter로 받는 경우도 있고, body로 받는 경우도 있어서 일단은 저번에 논의했던 validator클래스로 구현했습니다!