### PR TITLE
[FIX/#105] UserResponse에서 birthday 필드를 LocalDate 타입으로 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/dto/request/SocialAccountRequest.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/dto/request/SocialAccountRequest.java
@@ -2,7 +2,7 @@ package sopt.makers.authentication.application.auth.dto.request;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import sopt.makers.authentication.domain.auth.*;
+import sopt.makers.authentication.domain.auth.AuthPlatform;
 import sopt.makers.authentication.usecase.auth.port.in.UpdateSocialAccountUsecase.UpdateSocialAccountCommand;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
@@ -4,6 +4,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import sopt.makers.authentication.usecase.user.port.in.GetUserProfileUsecase;
 
+import java.time.*;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ public final class UserResponse {
       Long userId,
       String name,
       String profileImage,
-      String birthday,
+      LocalDate birthday,
       String phone,
       String email,
       Integer lastGeneration,

--- a/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
@@ -4,7 +4,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import sopt.makers.authentication.usecase.user.port.in.GetUserProfileUsecase;
 
-import java.time.*;
+import java.time.LocalDate;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/GoogleAuthService.java
@@ -1,6 +1,6 @@
 package sopt.makers.authentication.external.oauth;
 
-import static sopt.makers.authentication.support.constant.OAuthConstant.*;
+import static sopt.makers.authentication.support.constant.OAuthConstant.GOOGLE_ISSUER;
 
 import sopt.makers.authentication.external.oauth.client.GoogleAuthClient;
 import sopt.makers.authentication.support.code.domain.failure.AuthFailure;
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
-import com.nimbusds.jose.crypto.*;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.JWTClaimsSet;

--- a/src/main/java/sopt/makers/authentication/external/oauth/client/AppleAuthClient.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/client/AppleAuthClient.java
@@ -1,7 +1,8 @@
 package sopt.makers.authentication.external.oauth.client;
 
-import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
-import static sopt.makers.authentication.support.constant.OAuthConstant.*;
+import static sopt.makers.authentication.support.code.external.failure.ClientError.APPLE_REQUEST_FAIL;
+import static sopt.makers.authentication.support.code.external.failure.ClientError.INVALID_APPLE_REQUEST_URL;
+import static sopt.makers.authentication.support.constant.OAuthConstant.APPLE_PUBLIC_KEY_SET_URL;
 
 import sopt.makers.authentication.support.exception.external.ClientRequestException;
 import sopt.makers.authentication.support.exception.external.ClientResponseException;

--- a/src/main/java/sopt/makers/authentication/external/oauth/client/GoogleAuthClient.java
+++ b/src/main/java/sopt/makers/authentication/external/oauth/client/GoogleAuthClient.java
@@ -1,7 +1,8 @@
 package sopt.makers.authentication.external.oauth.client;
 
-import static sopt.makers.authentication.support.code.external.failure.ClientError.*;
-import static sopt.makers.authentication.support.constant.OAuthConstant.*;
+import static sopt.makers.authentication.support.code.external.failure.ClientError.GOOGLE_REQUEST_FAIL;
+import static sopt.makers.authentication.support.code.external.failure.ClientError.INVALID_GOOGLE_REQUEST_URL;
+import static sopt.makers.authentication.support.constant.OAuthConstant.GOOGLE_PUBLIC_KEY_SET_URL;
 
 import sopt.makers.authentication.support.exception.external.ClientRequestException;
 import sopt.makers.authentication.support.exception.external.ClientResponseException;

--- a/src/main/java/sopt/makers/authentication/support/code/domain/success/SocialAccountSuccess.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/success/SocialAccountSuccess.java
@@ -2,11 +2,12 @@ package sopt.makers.authentication.support.code.domain.success;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import sopt.makers.authentication.support.code.base.*;
+import sopt.makers.authentication.support.code.base.SuccessCode;
 
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)

--- a/src/main/java/sopt/makers/authentication/support/code/support/failure/CommonFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/support/failure/CommonFailure.java
@@ -2,11 +2,12 @@ package sopt.makers.authentication.support.code.support.failure;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import sopt.makers.authentication.support.code.base.*;
+import sopt.makers.authentication.support.code.base.FailureCode;
 
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)

--- a/src/main/java/sopt/makers/authentication/support/config/ApplicationConfig.java
+++ b/src/main/java/sopt/makers/authentication/support/config/ApplicationConfig.java
@@ -1,6 +1,9 @@
 package sopt.makers.authentication.support.config;
 
-import sopt.makers.authentication.support.value.*;
+import sopt.makers.authentication.support.value.AppleOAuthProperty;
+import sopt.makers.authentication.support.value.GabiaProperty;
+import sopt.makers.authentication.support.value.GoogleOAuthProperty;
+import sopt.makers.authentication.support.value.SecurityProperty;
 
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/src/main/java/sopt/makers/authentication/support/config/GsonConfig.java
+++ b/src/main/java/sopt/makers/authentication/support/config/GsonConfig.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.support.config;
 
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import com.google.gson.Gson;
 

--- a/src/main/java/sopt/makers/authentication/support/exception/ApplicationExceptionHandler.java
+++ b/src/main/java/sopt/makers/authentication/support/exception/ApplicationExceptionHandler.java
@@ -3,9 +3,10 @@ package sopt.makers.authentication.support.exception;
 import static sopt.makers.authentication.support.code.support.failure.CommonFailure.INTERNAL_SERVER_ERROR;
 
 import sopt.makers.authentication.support.common.api.BaseResponse;
-import sopt.makers.authentication.support.exception.base.*;
+import sopt.makers.authentication.support.exception.base.BaseException;
 
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 

--- a/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/auth/service/CreateVerificationService.java
@@ -17,7 +17,7 @@ import sopt.makers.authentication.usecase.user.port.out.UserRepository;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
@@ -5,6 +5,7 @@ import sopt.makers.authentication.domain.user.ActivityList;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 
+import java.time.*;
 import java.util.List;
 
 public interface GetUserProfileUsecase {
@@ -15,7 +16,7 @@ public interface GetUserProfileUsecase {
       Long userId,
       String name,
       String profileImage,
-      String birthday,
+      LocalDate birthday,
       String phone,
       String email,
       Integer lastGeneration,
@@ -30,7 +31,7 @@ public interface GetUserProfileUsecase {
           user.getId(),
           profile.name(),
           profile.profileImage().orElse(null),
-          profile.birthday().toString(),
+          profile.birthday(),
           profile.phone(),
           profile.email().orElse(null),
           activities.getLastActivity().getGeneration(),

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
@@ -5,7 +5,7 @@ import sopt.makers.authentication.domain.user.ActivityList;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 
-import java.time.*;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface GetUserProfileUsecase {

--- a/src/test/java/sopt/makers/authentication/AuthenticationApplicationTests.java
+++ b/src/test/java/sopt/makers/authentication/AuthenticationApplicationTests.java
@@ -3,7 +3,8 @@ package sopt.makers.authentication;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/auth/service/VerifyVerificationServiceTest.java
@@ -1,7 +1,8 @@
 package sopt.makers.authentication.usecase.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase.*;
+import static sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase.VerifyVerificationCommand;
+import static sopt.makers.authentication.usecase.auth.port.in.VerifyPhoneVerificationUsecase.VerifyVerificationResult;
 
 import sopt.makers.authentication.domain.auth.PhoneVerification;
 import sopt.makers.authentication.domain.auth.PhoneVerificationType;

--- a/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
+++ b/src/test/java/sopt/makers/authentication/usecase/user/service/UpdateUserProfileServiceTest.java
@@ -2,7 +2,10 @@ package sopt.makers.authentication.usecase.user.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.ActivityList;


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #105

## Work Description ✏️
- birthday 필드가 null인데 String으로 변환하려는 과정에서 다음과 같은 오류가 발생했습니다
`2025-06-04T01:52:58.624+09:00 ERROR 1 --- [nio-8080-exec-3] s.m.a.s.e.ApplicationExceptionHandler    : Cannot invoke "java.time.LocalDate.toString()" because the return value of "sopt.makers.authentication.domain.user.Profile.birthday()" is null`
- 확인해보니 유저 정보 수정에서도 Request에 LocalDate로 생일을 받고 있어, Response에서도 LocalDate를 사용하도록 변경하여 오류를 수정했습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 없습니당~! 코드 넘 잘 작성해줘서 금방해결했네요 ㅋ.ㅋ