### PR TITLE
[FEAT/#106] JwtAuthenticationFilter에서 Authorization Header가 없는 경우에 대한 예외처리 추가

### DIFF
--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
@@ -13,19 +13,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum AuthFailure implements FailureCode {
   // 400
-  INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다"),
+  INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 플랫폼입니다."),
   INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "ID 토큰 유효성 검사에 실패했습니다."),
   INVALID_PHONE_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
   ALREADY_REGISTER_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 가입된 전화번호입니다."),
   EXPIRED_PHONE_VERIFICATION(HttpStatus.BAD_REQUEST, "인증 시간이 만료되었습니다."),
 
   // 401
-  INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "API 키가 유효하지 않습니다"),
+  INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "API 키가 유효하지 않습니다."),
   MISSING_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 없습니다."),
 
   // 404
   NOT_FOUND_PHONE_VERIFICATION(HttpStatus.NOT_FOUND, "존재하지 않는 번호 인증 이력입니다."),
-  NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 계정 정보와 일치하는 회원이 없습니다"),
+  NOT_FOUND_USER_WITH_SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 계정 정보와 일치하는 회원이 없습니다."),
   NOT_FOUND_AVAILABLE_PUBLIC_KEY_SET(HttpStatus.NOT_FOUND, "유효한 Public Key Set를 찾을 수 없습니다."),
   NOT_FOUND_REGISTER_INFO(HttpStatus.NOT_FOUND, "가입 정보를 찾을 수 없습니다.");
 

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/AuthFailure.java
@@ -21,6 +21,7 @@ public enum AuthFailure implements FailureCode {
 
   // 401
   INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "API 키가 유효하지 않습니다"),
+  MISSING_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 없습니다."),
 
   // 404
   NOT_FOUND_PHONE_VERIFICATION(HttpStatus.NOT_FOUND, "존재하지 않는 번호 인증 이력입니다."),

--- a/src/main/java/sopt/makers/authentication/support/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/makers/authentication/support/security/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,9 @@
 package sopt.makers.authentication.support.security.filter;
 
+import static sopt.makers.authentication.support.code.domain.failure.AuthFailure.MISSING_AUTHORIZATION_HEADER;
 import static sopt.makers.authentication.support.constant.SystemConstant.WHITELIST_WILDCARD;
 
+import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.support.jwt.service.JwtAuthAccessTokenService;
 import sopt.makers.authentication.support.security.authentication.ApiKeyAuthentication;
 import sopt.makers.authentication.support.security.authentication.CustomAuthentication;
@@ -43,12 +45,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     filterChain.doFilter(request, response);
   }
 
-  /**
-   * @author 강현욱 @hyunw9
-   * @return JwtToken Authorization 헤더에서 "Bearer "를 제거하여 토큰을 추출합니다.
-   */
   private String getAuthorizationToken(final HttpServletRequest request) {
     String authorizationHeaderValue = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authorizationHeaderValue == null) {
+      throw new AuthException(MISSING_AUTHORIZATION_HEADER);
+    }
     return authorizationHeaderValue.trim();
   }
 


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #106

## Work Description ✏️
- 해당 작업 이전에는 Authorization 헤더가 필요한 경우에 이를 포함하지 않거나 값이 null인 경우에 500 예외가 전달되고 있었습니다
```
java.lang.NullPointerException: Cannot invoke "String.trim()" because "authorizationHeaderValue" is null
        at sopt.makers.authentication.support.security.filter.JwtAuthenticationFilter.getAuthorizationToken(JwtAuthenticationFilter.java:52) ~[!/:0.0.1-SNAPSHOT]
        at 
```
- 이러한 요청이 정상 요청은 아니지만, 401로 status를 명확하게 명시해주면 좋을 것 같아 예외처리를 추가해주었습니다

- 작업 이후
<img width="686" alt="image" src="https://github.com/user-attachments/assets/d4bc2bc3-4a92-40e5-9c2a-28c085c98ad0" />

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- X