### PR TITLE
[FEAT/#118] 기수, 파트별 유저 정보 조회 및 기수별 유저 수 조회 API 개발

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/user/api/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/application/user/api/UserApi.java
@@ -34,4 +34,9 @@ public interface UserApi {
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
       @RequestParam(required = false) Integer generation,
       @RequestParam(required = false) Part part);
+
+  ResponseEntity<BaseResponse<?>> getUserCountByGeneration(
+      @RequestHeader(API_KEY_HEADER) String apiKey,
+      @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
+      @RequestParam int generation);
 }

--- a/src/main/java/sopt/makers/authentication/application/user/api/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/application/user/api/UserApi.java
@@ -4,6 +4,7 @@ import static sopt.makers.authentication.support.constant.SystemConstant.API_KEY
 import static sopt.makers.authentication.support.constant.SystemConstant.SERVICE_NAME_HEADER;
 
 import sopt.makers.authentication.application.user.dto.request.UserRequest;
+import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 
 import java.util.List;
@@ -27,4 +28,10 @@ public interface UserApi {
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
       @PathVariable Long userId,
       @Valid @RequestBody UserRequest.UserProfileInfo userProfileInfo);
+
+  ResponseEntity<BaseResponse<?>> getUserProfileByActivity(
+      @RequestHeader(API_KEY_HEADER) String apiKey,
+      @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
+      @RequestParam(required = false) Integer generation,
+      @RequestParam(required = false) Part part);
 }

--- a/src/main/java/sopt/makers/authentication/application/user/api/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/user/api/UserApiController.java
@@ -5,10 +5,12 @@ import static sopt.makers.authentication.support.constant.SystemConstant.SERVICE
 
 import sopt.makers.authentication.application.user.dto.request.UserRequest;
 import sopt.makers.authentication.application.user.dto.response.UserResponse;
+import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.support.code.domain.success.UserSuccess;
 import sopt.makers.authentication.support.common.api.BaseResponse;
 import sopt.makers.authentication.support.util.ResponseUtil;
 import sopt.makers.authentication.support.validator.UserIdValidator;
+import sopt.makers.authentication.support.validator.UserSearchConditionValidator;
 import sopt.makers.authentication.usecase.user.port.in.GetUserProfileUsecase;
 import sopt.makers.authentication.usecase.user.port.in.UpdateUserProfileUsecase;
 
@@ -35,6 +37,7 @@ public class UserApiController implements UserApi {
   private final GetUserProfileUsecase getUserProfileUsecase;
   private final UpdateUserProfileUsecase updateUserProfileUsecase;
   private final UserIdValidator userIdValidator;
+  private final UserSearchConditionValidator userSearchConditionValidator;
 
   @GetMapping("")
   public ResponseEntity<BaseResponse<?>> getUserProfile(
@@ -59,5 +62,19 @@ public class UserApiController implements UserApi {
     updateUserProfileUsecase.updateUserProfile(userProfileInfo.toCommand(userId));
 
     return ResponseUtil.success(UserSuccess.UPDATE_USER_PROFILE);
+  }
+
+  @GetMapping("/search")
+  public ResponseEntity<BaseResponse<?>> getUserProfileByActivity(
+      @RequestHeader(API_KEY_HEADER) String apiKey,
+      @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
+      @RequestParam(required = false) Integer generation,
+      @RequestParam(required = false) Part part) {
+    userSearchConditionValidator.validateUserSearchCondition(generation, part);
+    List<GetUserProfileUsecase.UserProfileAndActivityInfo> userInformation =
+        getUserProfileUsecase.getUserInformationByActivity(generation, part);
+
+    return ResponseUtil.success(
+        UserSuccess.GET_USER_PROFILE, UserResponse.UserProfileAndActivity.from(userInformation));
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/user/api/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/user/api/UserApiController.java
@@ -77,4 +77,15 @@ public class UserApiController implements UserApi {
     return ResponseUtil.success(
         UserSuccess.GET_USER_PROFILE, UserResponse.UserProfileAndActivity.from(userInformation));
   }
+
+  @GetMapping("/count")
+  public ResponseEntity<BaseResponse<?>> getUserCountByGeneration(
+      @RequestHeader(API_KEY_HEADER) String apiKey,
+      @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
+      @RequestParam int generation) {
+    GetUserProfileUsecase.UserCountByGeneration count =
+        getUserProfileUsecase.getUserCountByGeneration(generation);
+    return ResponseUtil.success(
+        UserSuccess.GET_USER_COUNT, UserResponse.UserCountByGeneration.from(count));
+  }
 }

--- a/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/application/user/dto/response/UserResponse.java
@@ -53,4 +53,11 @@ public final class UserResponse {
           userActivityInfo.team());
     }
   }
+
+  public record UserCountByGeneration(int numberOfMembersAtGeneration) {
+    public static UserCountByGeneration from(
+        GetUserProfileUsecase.UserCountByGeneration userCountByGeneration) {
+      return new UserCountByGeneration(userCountByGeneration.count());
+    }
+  }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserJpaRepository.java
@@ -40,4 +40,13 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
             """)
   List<UserEntity> findAllWithActivityHistoriesByGenerationAndPart(
       @Param("generation") Integer generation, @Param("part") Part part);
+
+  @Query(
+      """
+        SELECT COUNT(DISTINCT u.id)
+        FROM UserEntity u
+        JOIN u.userActivityHistoryList a
+        WHERE a.generation = :generation
+    """)
+  int countByGeneration(@Param("generation") int generation);
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserJpaRepository.java
@@ -31,22 +31,18 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
   List<UserEntity> findAllWithActivityHistoriesByIdIn(@Param("userIds") List<Long> userIds);
 
   @Query(
-      """
-            SELECT DISTINCT u
-            FROM UserEntity u
-            JOIN FETCH u.userActivityHistoryList a
-            WHERE (:generation IS NULL OR a.generation = :generation)
-            AND (:part IS NULL OR a.part = :part)
-            """)
+      "SELECT DISTINCT u "
+          + "FROM UserEntity u "
+          + "JOIN FETCH u.userActivityHistoryList a "
+          + "WHERE (:generation IS NULL OR a.generation = :generation) "
+          + "AND (:part IS NULL OR a.part = :part)")
   List<UserEntity> findAllWithActivityHistoriesByGenerationAndPart(
       @Param("generation") Integer generation, @Param("part") Part part);
 
   @Query(
-      """
-        SELECT COUNT(DISTINCT u.id)
-        FROM UserEntity u
-        JOIN u.userActivityHistoryList a
-        WHERE a.generation = :generation
-    """)
+      "SELECT COUNT(DISTINCT u.id) "
+          + "FROM UserEntity u "
+          + "JOIN u.userActivityHistoryList a "
+          + "WHERE a.generation = :generation")
   int countByGeneration(@Param("generation") int generation);
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserJpaRepository.java
@@ -2,6 +2,7 @@ package sopt.makers.authentication.database.rdb.repository.user;
 
 import sopt.makers.authentication.database.rdb.entity.UserEntity;
 import sopt.makers.authentication.domain.auth.AuthPlatform;
+import sopt.makers.authentication.domain.user.Part;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,4 +29,15 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
   @Query(
       "SELECT DISTINCT u FROM UserEntity u JOIN FETCH u.userActivityHistoryList WHERE u.id IN :userIds")
   List<UserEntity> findAllWithActivityHistoriesByIdIn(@Param("userIds") List<Long> userIds);
+
+  @Query(
+      """
+            SELECT DISTINCT u
+            FROM UserEntity u
+            JOIN FETCH u.userActivityHistoryList a
+            WHERE (:generation IS NULL OR a.generation = :generation)
+            AND (:part IS NULL OR a.part = :part)
+            """)
+  List<UserEntity> findAllWithActivityHistoriesByGenerationAndPart(
+      @Param("generation") Integer generation, @Param("part") Part part);
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
@@ -2,6 +2,7 @@ package sopt.makers.authentication.database.rdb.repository.user;
 
 import sopt.makers.authentication.database.rdb.entity.UserEntity;
 import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.usecase.user.port.out.UserRepository;
@@ -67,5 +68,10 @@ public class UserRepositoryImpl implements UserRepository {
   @Override
   public boolean existsByPhone(String phone) {
     return userRetriever.existsByPhone(phone);
+  }
+
+  @Override
+  public List<User> findAllByActivity(Integer generation, Part part) {
+    return userRetriever.findAllByActivity(generation, part);
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
@@ -74,4 +74,9 @@ public class UserRepositoryImpl implements UserRepository {
   public List<User> findAllByActivity(Integer generation, Part part) {
     return userRetriever.findAllByActivity(generation, part);
   }
+
+  @Override
+  public int countByGeneration(int generation) {
+    return userRetriever.countByGeneration(generation);
+  }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRepositoryImpl.java
@@ -71,7 +71,7 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
-  public List<User> findAllByActivity(Integer generation, Part part) {
+  public List<User> findAllByGenerationAndPart(Integer generation, Part part) {
     return userRetriever.findAllByActivity(generation, part);
   }
 

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
@@ -5,6 +5,7 @@ import static sopt.makers.authentication.support.code.domain.failure.UserFailure
 
 import sopt.makers.authentication.database.rdb.entity.UserEntity;
 import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.support.exception.domain.AuthException;
 import sopt.makers.authentication.support.exception.domain.UserException;
@@ -46,5 +47,12 @@ public class UserRetriever {
 
   public boolean existsByPhone(String phone) {
     return userJpaRepository.existsByPhone(phone);
+  }
+
+  public List<User> findAllByActivity(Integer generation, Part part) {
+    List<UserEntity> userEntityList =
+        userJpaRepository.findAllWithActivityHistoriesByGenerationAndPart(generation, part);
+
+    return userEntityList.stream().map(UserEntity::toDomain).toList();
   }
 }

--- a/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/database/rdb/repository/user/UserRetriever.java
@@ -55,4 +55,8 @@ public class UserRetriever {
 
     return userEntityList.stream().map(UserEntity::toDomain).toList();
   }
+
+  public int countByGeneration(int generation) {
+    return userJpaRepository.countByGeneration(generation);
+  }
 }

--- a/src/main/java/sopt/makers/authentication/support/code/domain/failure/UserFailure.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/failure/UserFailure.java
@@ -16,6 +16,7 @@ public enum UserFailure implements FailureCode {
   DUPLICATE_ACTIVITY(HttpStatus.BAD_REQUEST, "이미 존재하는 활동 정보입니다"),
   ROLE_REQUIRES_PART(HttpStatus.BAD_REQUEST, "해당 Role은 Part가 필수입니다"),
   NOT_VALID_USER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 유저 ID 입니다"),
+  BAD_REQUEST_INVALID_USER_SEARCH_CONDITION(HttpStatus.BAD_REQUEST, "조회 조건 중 최소 하나는 입력해야 합니다."),
   // 404
   NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다"),
   NOT_FOUND_PART(HttpStatus.NOT_FOUND, "존재하지 않는 파트입니다"),

--- a/src/main/java/sopt/makers/authentication/support/code/domain/success/UserSuccess.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/success/UserSuccess.java
@@ -13,7 +13,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum UserSuccess implements SuccessCode {
   GET_USER_PROFILE(HttpStatus.OK, "유저 기본 정보 조회에 성공했습니다."),
-  UPDATE_USER_PROFILE(HttpStatus.OK, "유저 기본 정보 수정에 성공했습니다.");
+  UPDATE_USER_PROFILE(HttpStatus.OK, "유저 기본 정보 수정에 성공했습니다."),
+  GET_USER_COUNT(HttpStatus.OK, "유저 수 조회에 성공했습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/sopt/makers/authentication/support/validator/UserIdValidator.java
+++ b/src/main/java/sopt/makers/authentication/support/validator/UserIdValidator.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class UserIdValidator {
 
   public void validateUserIds(List<Long> userIds) {
-    if (userIds.stream().anyMatch(id -> id <= 0)) {
+    if (userIds != null && userIds.stream().anyMatch(id -> id <= 0)) {
       throw new UserException(NOT_VALID_USER_ID);
     }
   }

--- a/src/main/java/sopt/makers/authentication/support/validator/UserSearchConditionValidator.java
+++ b/src/main/java/sopt/makers/authentication/support/validator/UserSearchConditionValidator.java
@@ -1,0 +1,18 @@
+package sopt.makers.authentication.support.validator;
+
+import static sopt.makers.authentication.support.code.domain.failure.UserFailure.BAD_REQUEST_INVALID_USER_SEARCH_CONDITION;
+
+import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.support.exception.domain.UserException;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserSearchConditionValidator {
+
+  public void validateUserSearchCondition(Integer generation, Part part) {
+    if (generation == null && part == null) {
+      throw new UserException(BAD_REQUEST_INVALID_USER_SEARCH_CONDITION);
+    }
+  }
+}

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
@@ -15,6 +15,8 @@ public interface GetUserProfileUsecase {
 
   List<UserProfileAndActivityInfo> getUserInformationByActivity(Integer generation, Part part);
 
+  UserCountByGeneration getUserCountByGeneration(int generation);
+
   record UserProfileAndActivityInfo(
       Long userId,
       String name,
@@ -51,4 +53,6 @@ public interface GetUserProfileUsecase {
           activity.getTeam() != null ? activity.getTeam().getName() : null);
     }
   }
+
+  record UserCountByGeneration(int count) {}
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/in/GetUserProfileUsecase.java
@@ -2,6 +2,7 @@ package sopt.makers.authentication.usecase.user.port.in;
 
 import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.ActivityList;
+import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 
@@ -11,6 +12,8 @@ import java.util.List;
 public interface GetUserProfileUsecase {
 
   List<UserProfileAndActivityInfo> getUserInformation(List<Long> userIds);
+
+  List<UserProfileAndActivityInfo> getUserInformationByActivity(Integer generation, Part part);
 
   record UserProfileAndActivityInfo(
       Long userId,

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
@@ -25,7 +25,7 @@ public interface UserRepository {
 
   boolean existsByPhone(String phone);
 
-  List<User> findAllByActivity(Integer generation, Part part);
+  List<User> findAllByGenerationAndPart(Integer generation, Part part);
 
   int countByGeneration(int generation);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
@@ -26,4 +26,6 @@ public interface UserRepository {
   boolean existsByPhone(String phone);
 
   List<User> findAllByActivity(Integer generation, Part part);
+
+  int countByGeneration(int generation);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/port/out/UserRepository.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.usecase.user.port.out;
 
 import sopt.makers.authentication.domain.auth.SocialAccount;
+import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 
@@ -23,4 +24,6 @@ public interface UserRepository {
   void update(User user, Profile profile);
 
   boolean existsByPhone(String phone);
+
+  List<User> findAllByActivity(Integer generation, Part part);
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/GetUserProfileService.java
@@ -1,5 +1,6 @@
 package sopt.makers.authentication.usecase.user.service;
 
+import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.usecase.user.port.in.GetUserProfileUsecase;
 import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
@@ -21,11 +22,18 @@ public class GetUserProfileService implements GetUserProfileUsecase {
   @Override
   public List<UserProfileAndActivityInfo> getUserInformation(List<Long> userIds) {
     List<User> userList = userRepository.findAllById(userIds);
-    List<UserProfileAndActivityInfo> userProfileAndActivityInfos =
-        userList.stream()
-            .map(user -> UserProfileAndActivityInfo.of(user, user.getActivities()))
-            .toList();
 
-    return userProfileAndActivityInfos;
+    return userList.stream()
+        .map(user -> UserProfileAndActivityInfo.of(user, user.getActivities()))
+        .toList();
+  }
+
+  @Override
+  public List<UserProfileAndActivityInfo> getUserInformationByActivity(
+      Integer generation, Part part) {
+    List<User> userList = userRepository.findAllByActivity(generation, part);
+    return userList.stream()
+        .map(user -> UserProfileAndActivityInfo.of(user, user.getActivities()))
+        .toList();
   }
 }

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/GetUserProfileService.java
@@ -29,7 +29,7 @@ public class GetUserProfileService implements GetUserProfileUsecase {
   @Override
   public List<UserProfileAndActivityInfo> getUserInformationByActivity(
       Integer generation, Part part) {
-    List<User> userList = userRepository.findAllByActivity(generation, part);
+    List<User> userList = userRepository.findAllByGenerationAndPart(generation, part);
     return userList.stream()
         .map(user -> UserProfileAndActivityInfo.of(user, user.getActivities()))
         .toList();

--- a/src/main/java/sopt/makers/authentication/usecase/user/service/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/usecase/user/service/GetUserProfileService.java
@@ -3,7 +3,6 @@ package sopt.makers.authentication.usecase.user.service;
 import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.usecase.user.port.in.GetUserProfileUsecase;
-import sopt.makers.authentication.usecase.user.port.out.UserActivityHistoryRepository;
 import sopt.makers.authentication.usecase.user.port.out.UserRepository;
 
 import java.util.List;
@@ -17,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 public class GetUserProfileService implements GetUserProfileUsecase {
 
   private final UserRepository userRepository;
-  private final UserActivityHistoryRepository userActivityHistoryRepository;
 
   @Override
   public List<UserProfileAndActivityInfo> getUserInformation(List<Long> userIds) {
@@ -35,5 +33,11 @@ public class GetUserProfileService implements GetUserProfileUsecase {
     return userList.stream()
         .map(user -> UserProfileAndActivityInfo.of(user, user.getActivities()))
         .toList();
+  }
+
+  @Override
+  public UserCountByGeneration getUserCountByGeneration(int generation) {
+    int count = userRepository.countByGeneration(generation);
+    return new UserCountByGeneration(count);
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #118 

## Work Description ✏️
### users/search?generation=35&part=PLAN
- generation / part (최소 하나 필수) -> 하나의 API로 전체 회원 조회가 가능한 상황을 방지하기 위해 validator를 추가했습니다. 
- gerUserProfile과 같은 응답 사용

### users/count
- `{ "numberOfMembersAtGeneration": 123 }` 형태 응답

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
1️⃣ users/search API를 기존 user API에 통합할지, 별도로 분리할지
- API별 service 권한 분리 가능성 등을 고려해 별도 search API로 분리하여 구현했습니다.

2️⃣ GetUserProfileUsecase
- userId 기반 조회, generation + part 기반 조회, count 모두 user profile read 책임에 속하므로 하나의 usecase interface 내부에 함수 추가
- 기존 코드 스타일과 비교했을 때 구조가 일관적인지 리뷰 의견 주시면 감사하겠습니다.