### PR TITLE
[CHORE/#122] 환경별 로그 출력 형식 설정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,48 @@
+<configuration>
+    <springProfile name="local">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{36} - %msg%n
+                </pattern>
+            </encoder>
+        </appender>
+
+        <logger name="sopt.makers.authentication" level="DEBUG" />
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+         <logger name="org.hibernate.SQL" level="DEBUG"/>
+         <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>
+    </springProfile>
+
+    <springProfile name="dev">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{36} - %msg%n
+                </pattern>
+            </encoder>
+        </appender>
+
+        <logger name="sopt.makers.authentication" level="INFO" />
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+                </pattern>
+            </encoder>
+        </appender>
+
+        <logger name="sopt.makers.authentication" level="INFO" />
+        <root level="WARN">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #122 

## Work Description ✏️
- local: root=INFO + 서비스 코드 DEBUG + SQL/바인딩 로그 출력 (개발/디버깅을 위한 상세 로그 (SQL 포함))
- dev: root=INFO + 서비스 코드 INFO (noise 최소화 + 흐름 확인)
- prod: root=WARN + 서비스 코드 INFO (성능/보안 최적화 + 서비스 흐름 유지)

출력형식만 정해두고, Loki 설정 추가하여 로깅 구현할 예정입니다 !!  (인스턴스 내부에 저장 X, 모니터링 서버에 저장되도록 구현)

## Example 
`2025-06-17 22:23:36.773 [http-nio-port_num-exec-1] ERROR ExceptionHandler - 조회 조건 중 최소 하나는 입력해야 합니다.`

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
저장공간과 사용성을 고려했을 때 각 환경별 로그 레벨이 적절한지 피드백 받고 싶습니당