### PR TITLE
[FIX/#125] 토큰 재발급(app)시에 @RequestBody 누락된 문제 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/application/auth/api/AuthApiController.java
@@ -100,7 +100,7 @@ public class AuthApiController implements AuthApi {
     HttpHeaders headers = cookieUtil.setRefreshToken(tokenInfo.refreshToken());
 
     return ResponseUtil.success(
-        AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
+        AuthSuccess.REFRESH_TOKEN,
         headers,
         AuthResponse.AuthenticateSocialAuthInfoForWeb.of(tokenInfo.accessToken()));
   }
@@ -108,13 +108,13 @@ public class AuthApiController implements AuthApi {
   @Override
   @PostMapping("/refresh/app")
   public ResponseEntity<BaseResponse<?>> refreshTokenFromApp(
-      AuthRequest.AuthenticationTokenInfo authenticationTokenInfo) {
+      @RequestBody AuthRequest.AuthenticationTokenInfo authenticationTokenInfo) {
 
     AuthenticateTokenInfo tokenInfo =
         authenticateSocialAccountUsecase.refresh(authenticationTokenInfo.toCommand());
 
     return ResponseUtil.success(
-        AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
+        AuthSuccess.REFRESH_TOKEN,
         AuthResponse.AuthenticateSocialAuthInfoForApp.of(
             tokenInfo.accessToken(), tokenInfo.refreshToken()));
   }

--- a/src/main/java/sopt/makers/authentication/support/code/domain/success/AuthSuccess.java
+++ b/src/main/java/sopt/makers/authentication/support/code/domain/success/AuthSuccess.java
@@ -15,6 +15,7 @@ public enum AuthSuccess implements SuccessCode {
   // 200
   VERIFY_PHONE_VERIFICATION(HttpStatus.OK, "번호 인증에 성공했습니다."),
   AUTHENTICATE_SOCIAL_ACCOUNT(HttpStatus.OK, "소셜 로그인에 성공했습니다."),
+  REFRESH_TOKEN(HttpStatus.OK, "토큰 갱신에 성공했습니다."),
 
   // 201
   CREATE_PHONE_VERIFICATION(HttpStatus.CREATED, "번호 인증 생성에 성공했습니다."),


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #125 

## Work Description ✏️
- 토큰 재발급시에 @RequestBody 누락되어 있어서 아래와 같은 문제가 발생하여 추가했습니다!
```
{
  "success": false,
  "message": "서버 내부 오류입니다",
  "data": "An error occurred while attempting to decode the Jwt: Cannot invoke \"String.indexOf(String)\" because \"s\" is null"
}
```

- response body 수정
web, app 모두 재발급 성공시에 success가 잘못된 내용이 나가고 있어서 수정했습니다!

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
