### PR TITLE
[FIX/#127] request로 전달된 이름 및 전화번호가 아닌 인증 이력에 저장된 정보를 바탕으로 이름, 전화번호를 전달하도록 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/dto/auth/request/AuthRequest.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/dto/auth/request/AuthRequest.java
@@ -28,16 +28,12 @@ public final class AuthRequest {
   }
 
   public record VerifyPhoneVerification(
-      @JsonProperty("name") String name,
       @JsonProperty("phone") String number,
       @JsonProperty("code") String code,
       @JsonProperty("type") String verificationTypeName) {
     public VerifyVerificationCommand toCommand() {
       return new VerifyVerificationCommand(
-          this.name,
-          this.number,
-          this.code,
-          PhoneVerificationType.valueOf(this.verificationTypeName));
+          this.number, this.code, PhoneVerificationType.valueOf(this.verificationTypeName));
     }
   }
 

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/PhoneVerificationEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/PhoneVerificationEntity.java
@@ -39,7 +39,6 @@ public class PhoneVerificationEntity extends BaseEntity {
 
   private PhoneVerificationEntity(PhoneVerification verification) {
     super();
-    this.name = verification.getName();
     this.phone = verification.getPhone();
     this.code = verification.getVerificationCode().getCode();
     this.type = verification.getVerificationType();

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/PhoneVerificationEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/PhoneVerificationEntity.java
@@ -39,6 +39,7 @@ public class PhoneVerificationEntity extends BaseEntity {
 
   private PhoneVerificationEntity(PhoneVerification verification) {
     super();
+    this.name = verification.getName();
     this.phone = verification.getPhone();
     this.code = verification.getVerificationCode().getCode();
     this.type = verification.getVerificationType();

--- a/src/main/java/sopt/makers/authentication/application/port/in/auth/VerifyPhoneVerificationUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/auth/VerifyPhoneVerificationUsecase.java
@@ -7,7 +7,7 @@ public interface VerifyPhoneVerificationUsecase {
   VerifyVerificationResult verify(VerifyVerificationCommand command);
 
   record VerifyVerificationCommand(
-      String name, String phone, String code, PhoneVerificationType verificationType) {}
+      String phone, String code, PhoneVerificationType verificationType) {}
 
   record VerifyVerificationResult(String targetName, String targetPhone) {}
 }

--- a/src/main/java/sopt/makers/authentication/application/service/auth/VerifyVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/VerifyVerificationService.java
@@ -22,8 +22,7 @@ public class VerifyVerificationService implements VerifyPhoneVerificationUsecase
   @Transactional
   public VerifyVerificationResult verify(VerifyVerificationCommand command) {
     PhoneVerification targetVerification =
-        PhoneVerification.of(
-            command.name(), command.phone(), command.verificationType(), command.code());
+        PhoneVerification.of(command.phone(), command.verificationType(), command.code());
     PhoneVerification findVerification =
         phoneVerificationRepository.findByPhoneVerification(targetVerification);
 

--- a/src/main/java/sopt/makers/authentication/application/service/auth/VerifyVerificationService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/VerifyVerificationService.java
@@ -42,6 +42,7 @@ public class VerifyVerificationService implements VerifyPhoneVerificationUsecase
     PhoneVerification verifiedVerification = findVerification.updateIsVerified();
     phoneVerificationRepository.update(verifiedVerification);
 
-    return new VerifyVerificationResult(command.name(), command.phone());
+    return new VerifyVerificationResult(
+        verifiedVerification.getName(), verifiedVerification.getPhone());
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/auth/PhoneVerification.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/PhoneVerification.java
@@ -26,23 +26,12 @@ public class PhoneVerification {
   private final LocalDateTime createdAt;
   private final boolean isVerified;
 
-  public static PhoneVerification of(
-      Long id,
-      String name,
-      String phone,
-      PhoneVerificationType type,
-      String code,
-      LocalDateTime createdAt,
-      boolean isVerified) {
+  public static PhoneVerification of(String phone, PhoneVerificationType type, String code) {
     VerificationCode verificationCode = VerificationCode.of(code);
     return PhoneVerification.builder()
-        .id(id)
-        .name(name)
         .phone(phone)
         .verificationType(type)
         .verificationCode(verificationCode)
-        .createdAt(createdAt)
-        .isVerified(isVerified)
         .build();
   }
 
@@ -56,6 +45,26 @@ public class PhoneVerification {
         .verificationCode(verificationCode)
         .createdAt(null)
         .isVerified(false)
+        .build();
+  }
+
+  public static PhoneVerification of(
+      Long id,
+      String name,
+      String phone,
+      PhoneVerificationType type,
+      String code,
+      LocalDateTime createdAt,
+      boolean isVerified) {
+    VerificationCode verificationCode = VerificationCode.of(code);
+    return PhoneVerification.builder()
+        .id(id)
+        .name(name)
+        .phone(phone)
+        .verificationCode(verificationCode)
+        .verificationType(type)
+        .createdAt(createdAt)
+        .isVerified(isVerified)
         .build();
   }
 


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #127

## Work Description ✏️
- 이슈에 언급된 문제를 해결하고자 전화번호 인증 시 데이터베이스에서 조회한 값으로 이름, 전화번호를 response로 전달하도록 로직을 수정했습니다!

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- X