### PR TITLE
[FIX] 유저 정보 조회에서 profile domain 변환시 이미지도 넘기도록 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
@@ -86,7 +86,7 @@ public class UserEntity extends BaseEntity {
 
   public User toDomain() {
     SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType);
-    Profile profile = Profile.of(name, email, phone, birthday);
+    Profile profile = Profile.of(name, email, phone, birthday, profileImage);
     if (userActivityHistoryList == null || userActivityHistoryList.isEmpty()) {
       return User.createUser(super.getId(), socialAccount, profile);
     }

--- a/src/main/java/sopt/makers/authentication/domain/user/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Profile.java
@@ -16,6 +16,12 @@ public record Profile(
     return new Profile(name, Optional.ofNullable(email), phone, birthday, Optional.empty());
   }
 
+  public static Profile of(
+      String name, String email, String phone, LocalDate birthday, String profileImage) {
+    return new Profile(
+        name, Optional.ofNullable(email), phone, birthday, Optional.ofNullable(profileImage));
+  }
+
   public Profile updateProfile(
       String email, String phone, LocalDate birthday, String profileImage) {
     return new Profile(


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #133 

## Work Description ✏️
-  유저 정보 조회에서 profile domain 변환시 이미지도 넘기도록 수정했습니다!
   - 유저 이미지 없을때는 그대로 null 반환

<img width="853" height="387" alt="스크린샷 2025-07-16 오후 6 37 35" src="https://github.com/user-attachments/assets/c4623a80-c143-4055-a7c1-22f502a9dba9" />

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
