### PR TITLE
[FEAT] 매직 넘버 심사를 위한 회원가입 로직에 관련 로직 추가

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
@@ -10,7 +10,6 @@ import sopt.makers.authentication.application.port.out.user.UserRegisterInfoRepo
 import sopt.makers.authentication.application.port.out.user.UserRepository;
 import sopt.makers.authentication.application.validator.auth.PhoneVerificationValidator;
 import sopt.makers.authentication.domain.auth.AuthPlatform;
-import sopt.makers.authentication.domain.auth.PhoneVerificationType;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.auth.exception.AuthException;
 import sopt.makers.authentication.domain.user.Activity;
@@ -36,26 +35,35 @@ public class SignUpService implements SignUpUsecase {
   @Transactional
   @Override
   public void signUp(SignUpCommand command) {
-    if (!isMagicPhone(command.phone())) {
-      phoneVerificationValidator.validate(
-          command.name(), command.phone(), PhoneVerificationType.REGISTER);
+    if (isMagicPhone(command.phone())) {
+      signUpForMagicNumber(command.token(), command.authPlatform());
+    } else {
+      signUpForSoptUser(command.phone(), command.authPlatform());
     }
-    String authPlatformId =
-        oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
+  }
+
+  private void signUpForMagicNumber(String token, AuthPlatform authPlatform) {
+    User user = userRepository.findByPhone(magicLoginProperty.phone());
+    String authPlatformId = oAuthAuthenticator.getIdentifier(token, authPlatform);
+    SocialAccount updatedSocialAccount = createSocialAccount(authPlatformId, authPlatform);
+    User updatedUser = user.updateSocialAccount(updatedSocialAccount);
+    userRepository.save(updatedUser);
+  }
+
+  private void signUpForSoptUser(String phone, AuthPlatform authPlatform) {
+    //    String authPlatformId =
+    //            oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     UserRegisterInfo targetRegisterInfo =
         userRegisterInfoRepository
-            .findByPhone(command.phone())
+            .findByPhone(phone)
             .orElseThrow(() -> new AuthException(NOT_FOUND_REGISTER_INFO));
-    SocialAccount socialAccount = createSocialAccount(authPlatformId, command.authPlatform());
+    SocialAccount socialAccount = createSocialAccount(auth, authPlatform);
     Profile profile = createProfile(targetRegisterInfo);
     Activity activity = createActivity(targetRegisterInfo);
     User newUser = User.createNewUser(socialAccount, profile);
     User savedUser = userRepository.save(newUser);
 
     userActivityHistoryRepository.save(savedUser, activity);
-    if (isMagicPhone(command.phone())) {
-      return;
-    }
     userRegisterInfoRepository.delete(targetRegisterInfo);
   }
 

--- a/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
@@ -2,6 +2,7 @@ package sopt.makers.authentication.application.service.auth;
 
 import static sopt.makers.authentication.domain.auth.exception.AuthFailure.NOT_FOUND_REGISTER_INFO;
 
+import sopt.makers.authentication.adapter.out.external.oauth.MagicLoginProperty;
 import sopt.makers.authentication.application.port.in.auth.SignUpUsecase;
 import sopt.makers.authentication.application.port.out.auth.OAuthAuthenticator;
 import sopt.makers.authentication.application.port.out.user.UserActivityHistoryRepository;
@@ -30,12 +31,15 @@ public class SignUpService implements SignUpUsecase {
   private final UserRegisterInfoRepository userRegisterInfoRepository;
   private final UserActivityHistoryRepository userActivityHistoryRepository;
   private final PhoneVerificationValidator phoneVerificationValidator;
+  private final MagicLoginProperty magicLoginProperty;
 
   @Transactional
   @Override
   public void signUp(SignUpCommand command) {
-    phoneVerificationValidator.validate(
-        command.name(), command.phone(), PhoneVerificationType.REGISTER);
+    if (!isMagicPhone(command.phone())) {
+      phoneVerificationValidator.validate(
+          command.name(), command.phone(), PhoneVerificationType.REGISTER);
+    }
     String authPlatformId =
         oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
     UserRegisterInfo targetRegisterInfo =
@@ -49,6 +53,9 @@ public class SignUpService implements SignUpUsecase {
     User savedUser = userRepository.save(newUser);
 
     userActivityHistoryRepository.save(savedUser, activity);
+    if (isMagicPhone(command.phone())) {
+      return;
+    }
     userRegisterInfoRepository.delete(targetRegisterInfo);
   }
 
@@ -69,5 +76,9 @@ public class SignUpService implements SignUpUsecase {
 
   private Activity createActivity(UserRegisterInfo registerInfo) {
     return Activity.of(registerInfo.getGeneration(), null, registerInfo.getPart());
+  }
+
+  private boolean isMagicPhone(String phone) {
+    return (phone.equals(magicLoginProperty.phone()));
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
@@ -38,7 +38,7 @@ public class SignUpService implements SignUpUsecase {
     if (isMagicPhone(command.phone())) {
       signUpForMagicNumber(command.token(), command.authPlatform());
     } else {
-      signUpForSoptUser(command.phone(), command.authPlatform());
+      signUpForSoptUser(command.token(), command.phone(), command.authPlatform());
     }
   }
 
@@ -50,14 +50,13 @@ public class SignUpService implements SignUpUsecase {
     userRepository.save(updatedUser);
   }
 
-  private void signUpForSoptUser(String phone, AuthPlatform authPlatform) {
-    //    String authPlatformId =
-    //            oAuthAuthenticator.getIdentifier(command.token(), command.authPlatform());
+  private void signUpForSoptUser(String token, String phone, AuthPlatform authPlatform) {
+    String authPlatformId = oAuthAuthenticator.getIdentifier(token, authPlatform);
     UserRegisterInfo targetRegisterInfo =
         userRegisterInfoRepository
             .findByPhone(phone)
             .orElseThrow(() -> new AuthException(NOT_FOUND_REGISTER_INFO));
-    SocialAccount socialAccount = createSocialAccount(auth, authPlatform);
+    SocialAccount socialAccount = createSocialAccount(authPlatformId, authPlatform);
     Profile profile = createProfile(targetRegisterInfo);
     Activity activity = createActivity(targetRegisterInfo);
     User newUser = User.createNewUser(socialAccount, profile);


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #132 

## Work Description ✏️
- 매직 넘버 심사를 위한 회원가입 로직에 관련 로직 추가
  - 최종 Flow는 아래와 같아요! (`signUpForMagicNumber`와 `signUpForSoptUser` 메서드 분리)
     - 매직넘버 유저는 Users DB에 이미 존재하고 있는 상태 (테스트용 유저의 계정은 하나로 유지)
     - 기존 테스트 계정 조회 후 소셜 플랫폼 및 auth_platform_id 업데이트


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
