### PR TITLE
[FEAT/#135] 유저 조회에 name, team 조건 및 페이지네이션 추가

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 
 import org.springframework.http.ResponseEntity;
@@ -44,7 +45,7 @@ public interface UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
-      @RequestParam(defaultValue = DEFAULT_OFFSET) int offset,
+      @RequestParam(defaultValue = DEFAULT_OFFSET) @Min(0) int offset,
       @RequestParam(defaultValue = DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
       @RequestParam(defaultValue = DEFAULT_ORDER_BY) UserOrderBy orderBy);
 

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -6,6 +6,7 @@ import static sopt.makers.authentication.common.constant.SystemConstant.SERVICE_
 import sopt.makers.authentication.adapter.in.web.common.BaseResponse;
 import sopt.makers.authentication.adapter.in.web.dto.user.request.UserRequest;
 import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.domain.user.Team;
 
 import java.util.List;
 
@@ -35,6 +36,7 @@ public interface UserApi {
       @RequestParam(required = false) Integer generation,
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
+      @RequestParam(required = false) Team team,
       @RequestParam(defaultValue = "0") Integer offset,
       @RequestParam(defaultValue = "30") Integer limit);
 

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -1,5 +1,6 @@
 package sopt.makers.authentication.adapter.in.web.controller.user;
 
+import static sopt.makers.authentication.common.constant.PagingConstant.*;
 import static sopt.makers.authentication.common.constant.SystemConstant.API_KEY_HEADER;
 import static sopt.makers.authentication.common.constant.SystemConstant.SERVICE_NAME_HEADER;
 
@@ -7,6 +8,7 @@ import sopt.makers.authentication.adapter.in.web.common.BaseResponse;
 import sopt.makers.authentication.adapter.in.web.dto.user.request.UserRequest;
 import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Team;
+import sopt.makers.authentication.domain.user.UserOrderBy;
 
 import java.util.List;
 
@@ -39,8 +41,9 @@ public interface UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
-      @RequestParam(defaultValue = "0") int offset,
-      @RequestParam(defaultValue = "30") @Positive @Max(30) int limit);
+      @RequestParam(defaultValue = "" + DEFAULT_OFFSET) int offset,
+      @RequestParam(defaultValue = "" + DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
+      @RequestParam(defaultValue = DEFAULT_ORDER_BY) UserOrderBy orderBy);
 
   ResponseEntity<BaseResponse<?>> getUserCountByGeneration(
       @RequestHeader(API_KEY_HEADER) String apiKey,

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -1,6 +1,9 @@
 package sopt.makers.authentication.adapter.in.web.controller.user;
 
-import static sopt.makers.authentication.common.constant.PagingConstant.*;
+import static sopt.makers.authentication.common.constant.PagingConstant.DEFAULT_LIMIT;
+import static sopt.makers.authentication.common.constant.PagingConstant.DEFAULT_OFFSET;
+import static sopt.makers.authentication.common.constant.PagingConstant.DEFAULT_ORDER_BY;
+import static sopt.makers.authentication.common.constant.PagingConstant.MAX_LIMIT;
 import static sopt.makers.authentication.common.constant.SystemConstant.API_KEY_HEADER;
 import static sopt.makers.authentication.common.constant.SystemConstant.SERVICE_NAME_HEADER;
 

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -11,6 +11,7 @@ import sopt.makers.authentication.domain.user.Team;
 import java.util.List;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,7 +39,7 @@ public interface UserApi {
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
       @RequestParam(defaultValue = "0") Integer offset,
-      @RequestParam(defaultValue = "30") Integer limit);
+      @RequestParam(defaultValue = "30") @Positive Integer limit);
 
   ResponseEntity<BaseResponse<?>> getUserCountByGeneration(
       @RequestHeader(API_KEY_HEADER) String apiKey,

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -39,8 +39,8 @@ public interface UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
-      @RequestParam(defaultValue = "0") Integer offset,
-      @RequestParam(defaultValue = "30") @Positive @Max(30) Integer limit);
+      @RequestParam(defaultValue = "0") int offset,
+      @RequestParam(defaultValue = "30") @Positive @Max(30) int limit);
 
   ResponseEntity<BaseResponse<?>> getUserCountByGeneration(
       @RequestHeader(API_KEY_HEADER) String apiKey,

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -29,11 +29,14 @@ public interface UserApi {
       @PathVariable Long userId,
       @Valid @RequestBody UserRequest.UserProfileInfo userProfileInfo);
 
-  ResponseEntity<BaseResponse<?>> getUserProfileByActivity(
+  ResponseEntity<BaseResponse<?>> getUserProfileByFilters(
       @RequestHeader(API_KEY_HEADER) String apiKey,
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
       @RequestParam(required = false) Integer generation,
-      @RequestParam(required = false) Part part);
+      @RequestParam(required = false) Part part,
+      @RequestParam(required = false) String name,
+      @RequestParam(defaultValue = "0") Integer offset,
+      @RequestParam(defaultValue = "30") Integer limit);
 
   ResponseEntity<BaseResponse<?>> getUserCountByGeneration(
       @RequestHeader(API_KEY_HEADER) String apiKey,

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -11,6 +11,7 @@ import sopt.makers.authentication.domain.user.Team;
 import java.util.List;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
 
 import org.springframework.http.ResponseEntity;
@@ -39,7 +40,7 @@ public interface UserApi {
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
       @RequestParam(defaultValue = "0") Integer offset,
-      @RequestParam(defaultValue = "30") @Positive Integer limit);
+      @RequestParam(defaultValue = "30") @Positive @Max(30) Integer limit);
 
   ResponseEntity<BaseResponse<?>> getUserCountByGeneration(
       @RequestHeader(API_KEY_HEADER) String apiKey,

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -41,8 +41,8 @@ public interface UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
-      @RequestParam(defaultValue = "" + DEFAULT_OFFSET) int offset,
-      @RequestParam(defaultValue = "" + DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
+      @RequestParam(defaultValue = DEFAULT_OFFSET) int offset,
+      @RequestParam(defaultValue = DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
       @RequestParam(defaultValue = DEFAULT_ORDER_BY) UserOrderBy orderBy);
 
   ResponseEntity<BaseResponse<?>> getUserCountByGeneration(

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -77,8 +77,8 @@ public class UserApiController implements UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
-      @RequestParam(defaultValue = "0") Integer offset,
-      @RequestParam(defaultValue = "30") @Positive @Max(30) Integer limit) {
+      @RequestParam(defaultValue = "0") int offset,
+      @RequestParam(defaultValue = "30") @Positive @Max(30) int limit) {
     userSearchConditionValidator.validateUserSearchCondition(generation, part, name, team);
     GetUserProfileUsecase.PaginatedUserProfiles userInformation =
         getUserProfileUsecase.getUserInformationByFilters(

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -65,17 +65,20 @@ public class UserApiController implements UserApi {
   }
 
   @GetMapping("/search")
-  public ResponseEntity<BaseResponse<?>> getUserProfileByActivity(
+  public ResponseEntity<BaseResponse<?>> getUserProfileByFilters(
       @RequestHeader(API_KEY_HEADER) String apiKey,
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
       @RequestParam(required = false) Integer generation,
-      @RequestParam(required = false) Part part) {
-    userSearchConditionValidator.validateUserSearchCondition(generation, part);
-    List<GetUserProfileUsecase.UserProfileAndActivityInfo> userInformation =
-        getUserProfileUsecase.getUserInformationByActivity(generation, part);
+      @RequestParam(required = false) Part part,
+      @RequestParam(required = false) String name,
+      @RequestParam(defaultValue = "0") Integer offset,
+      @RequestParam(defaultValue = "30") Integer limit) {
+    userSearchConditionValidator.validateUserSearchCondition(generation, part, name);
+    GetUserProfileUsecase.PaginatedUserProfiles userInformation =
+        getUserProfileUsecase.getUserInformationByFilters(generation, part, name, offset, limit);
 
     return ResponseUtil.success(
-        UserSuccess.GET_USER_PROFILE, UserResponse.UserProfileAndActivity.from(userInformation));
+        UserSuccess.GET_USER_PROFILE, UserResponse.PaginatedUserProfiles.from(userInformation));
   }
 
   @GetMapping("/count")

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -18,6 +18,7 @@ import sopt.makers.authentication.domain.user.Team;
 import java.util.List;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
 
 import org.springframework.http.ResponseEntity;
@@ -77,7 +78,7 @@ public class UserApiController implements UserApi {
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
       @RequestParam(defaultValue = "0") Integer offset,
-      @RequestParam(defaultValue = "30") @Positive Integer limit) {
+      @RequestParam(defaultValue = "30") @Positive @Max(30) Integer limit) {
     userSearchConditionValidator.validateUserSearchCondition(generation, part, name, team);
     GetUserProfileUsecase.PaginatedUserProfiles userInformation =
         getUserProfileUsecase.getUserInformationByFilters(

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -1,6 +1,9 @@
 package sopt.makers.authentication.adapter.in.web.controller.user;
 
-import static sopt.makers.authentication.common.constant.PagingConstant.*;
+import static sopt.makers.authentication.common.constant.PagingConstant.DEFAULT_LIMIT;
+import static sopt.makers.authentication.common.constant.PagingConstant.DEFAULT_OFFSET;
+import static sopt.makers.authentication.common.constant.PagingConstant.DEFAULT_ORDER_BY;
+import static sopt.makers.authentication.common.constant.PagingConstant.MAX_LIMIT;
 import static sopt.makers.authentication.common.constant.SystemConstant.API_KEY_HEADER;
 import static sopt.makers.authentication.common.constant.SystemConstant.SERVICE_NAME_HEADER;
 

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 
 import org.springframework.http.ResponseEntity;
@@ -82,7 +83,7 @@ public class UserApiController implements UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
-      @RequestParam(defaultValue = DEFAULT_OFFSET) int offset,
+      @RequestParam(defaultValue = DEFAULT_OFFSET) @Min(0) int offset,
       @RequestParam(defaultValue = DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
       @RequestParam(defaultValue = DEFAULT_ORDER_BY) UserOrderBy orderBy) {
     userSearchConditionValidator.validateUserSearchCondition(generation, part, name, team);

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -1,5 +1,6 @@
 package sopt.makers.authentication.adapter.in.web.controller.user;
 
+import static sopt.makers.authentication.common.constant.PagingConstant.*;
 import static sopt.makers.authentication.common.constant.SystemConstant.API_KEY_HEADER;
 import static sopt.makers.authentication.common.constant.SystemConstant.SERVICE_NAME_HEADER;
 
@@ -14,6 +15,7 @@ import sopt.makers.authentication.application.validator.user.UserIdValidator;
 import sopt.makers.authentication.application.validator.user.UserSearchConditionValidator;
 import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Team;
+import sopt.makers.authentication.domain.user.UserOrderBy;
 
 import java.util.List;
 
@@ -77,12 +79,13 @@ public class UserApiController implements UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
-      @RequestParam(defaultValue = "0") int offset,
-      @RequestParam(defaultValue = "30") @Positive @Max(30) int limit) {
+      @RequestParam(defaultValue = "" + DEFAULT_OFFSET) int offset,
+      @RequestParam(defaultValue = "" + DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
+      @RequestParam(defaultValue = DEFAULT_ORDER_BY) UserOrderBy orderBy) {
     userSearchConditionValidator.validateUserSearchCondition(generation, part, name, team);
     GetUserProfileUsecase.PaginatedUserProfiles userInformation =
         getUserProfileUsecase.getUserInformationByFilters(
-            generation, part, name, team, offset, limit);
+            generation, part, name, team, offset, limit, orderBy);
 
     return ResponseUtil.success(
         UserSuccess.GET_USER_PROFILE, UserResponse.PaginatedUserProfiles.from(userInformation));

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -79,8 +79,8 @@ public class UserApiController implements UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
-      @RequestParam(defaultValue = "" + DEFAULT_OFFSET) int offset,
-      @RequestParam(defaultValue = "" + DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
+      @RequestParam(defaultValue = DEFAULT_OFFSET) int offset,
+      @RequestParam(defaultValue = DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
       @RequestParam(defaultValue = DEFAULT_ORDER_BY) UserOrderBy orderBy) {
     userSearchConditionValidator.validateUserSearchCondition(generation, part, name, team);
     GetUserProfileUsecase.PaginatedUserProfiles userInformation =

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -13,6 +13,7 @@ import sopt.makers.authentication.application.port.in.user.UpdateUserProfileUsec
 import sopt.makers.authentication.application.validator.user.UserIdValidator;
 import sopt.makers.authentication.application.validator.user.UserSearchConditionValidator;
 import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.domain.user.Team;
 
 import java.util.List;
 
@@ -71,11 +72,13 @@ public class UserApiController implements UserApi {
       @RequestParam(required = false) Integer generation,
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
+      @RequestParam(required = false) Team team,
       @RequestParam(defaultValue = "0") Integer offset,
       @RequestParam(defaultValue = "30") Integer limit) {
-    userSearchConditionValidator.validateUserSearchCondition(generation, part, name);
+    userSearchConditionValidator.validateUserSearchCondition(generation, part, name, team);
     GetUserProfileUsecase.PaginatedUserProfiles userInformation =
-        getUserProfileUsecase.getUserInformationByFilters(generation, part, name, offset, limit);
+        getUserProfileUsecase.getUserInformationByFilters(
+            generation, part, name, team, offset, limit);
 
     return ResponseUtil.success(
         UserSuccess.GET_USER_PROFILE, UserResponse.PaginatedUserProfiles.from(userInformation));

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -18,8 +18,10 @@ import sopt.makers.authentication.domain.user.Team;
 import java.util.List;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -34,6 +36,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
+@Validated
 public class UserApiController implements UserApi {
   private final GetUserProfileUsecase getUserProfileUsecase;
   private final UpdateUserProfileUsecase updateUserProfileUsecase;
@@ -74,7 +77,7 @@ public class UserApiController implements UserApi {
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
       @RequestParam(defaultValue = "0") Integer offset,
-      @RequestParam(defaultValue = "30") Integer limit) {
+      @RequestParam(defaultValue = "30") @Positive Integer limit) {
     userSearchConditionValidator.validateUserSearchCondition(generation, part, name, team);
     GetUserProfileUsecase.PaginatedUserProfiles userInformation =
         getUserProfileUsecase.getUserInformationByFilters(

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
@@ -60,4 +60,16 @@ public final class UserResponse {
       return new UserCountByGeneration(userCountByGeneration.count());
     }
   }
+
+  public record PaginatedUserProfiles(
+      List<UserProfileAndActivity> profiles, boolean hasNext, int totalCount) {
+    public static PaginatedUserProfiles from(
+        GetUserProfileUsecase.PaginatedUserProfiles paginatedData) {
+      List<UserProfileAndActivity> profiles =
+          paginatedData.profiles().stream().map(UserProfileAndActivity::from).toList();
+
+      return new PaginatedUserProfiles(
+          profiles, paginatedData.hasNext(), paginatedData.totalCount());
+    }
+  }
 }

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
@@ -62,12 +62,11 @@ public final class UserResponse {
   }
 
   public record PaginatedUserProfiles(
-      List<UserProfileAndActivity> profiles, boolean hasNext, int totalCount) {
+      List<UserProfileAndActivity> profiles, boolean hasNext, long totalCount) {
     public static PaginatedUserProfiles from(
         GetUserProfileUsecase.PaginatedUserProfiles paginatedData) {
       List<UserProfileAndActivity> profiles =
           paginatedData.profiles().stream().map(UserProfileAndActivity::from).toList();
-
       return new PaginatedUserProfiles(
           profiles, paginatedData.hasNext(), paginatedData.totalCount());
     }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
@@ -7,6 +7,8 @@ import sopt.makers.authentication.domain.user.Part;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -35,9 +37,13 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
           + "FROM UserEntity u "
           + "JOIN FETCH u.userActivityHistoryList a "
           + "WHERE (:generation IS NULL OR a.generation = :generation) "
-          + "AND (:part IS NULL OR a.part = :part)")
-  List<UserEntity> findAllWithActivityHistoriesByGenerationAndPart(
-      @Param("generation") Integer generation, @Param("part") Part part);
+          + "AND (:part IS NULL OR a.part = :part) "
+          + "AND (:name IS NULL OR u.name LIKE %:name%)")
+  Page<UserEntity> findAllWithActivityHistoriesByGenerationAndPartAndName(
+      @Param("generation") Integer generation,
+      @Param("part") Part part,
+      @Param("name") String name,
+      Pageable pageable);
 
   @Query(
       "SELECT COUNT(DISTINCT u.id) "

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
@@ -3,6 +3,7 @@ package sopt.makers.authentication.adapter.out.persistence.repository.user;
 import sopt.makers.authentication.adapter.out.persistence.entity.UserEntity;
 import sopt.makers.authentication.domain.auth.AuthPlatform;
 import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.domain.user.Team;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,11 +39,13 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
           + "JOIN FETCH u.userActivityHistoryList a "
           + "WHERE (:generation IS NULL OR a.generation = :generation) "
           + "AND (:part IS NULL OR a.part = :part) "
-          + "AND (:name IS NULL OR u.name LIKE %:name%)")
-  Page<UserEntity> findAllWithActivityHistoriesByGenerationAndPartAndName(
+          + "AND (:name IS NULL OR u.name LIKE %:name%) "
+          + "AND (:team IS NULL OR a.team = :team)")
+  Page<UserEntity> findAllWithActivityHistoriesByGenerationAndPartAndNameAndTeam(
       @Param("generation") Integer generation,
       @Param("part") Part part,
       @Param("name") String name,
+      @Param("team") Team team,
       Pageable pageable);
 
   @Query(

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
@@ -5,6 +5,7 @@ import sopt.makers.authentication.application.port.out.user.UserRepository;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Profile;
+import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
 
 import java.util.List;
@@ -73,9 +74,10 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
-  public Page<User> findAllByGenerationAndPartAndName(
-      Integer generation, Part part, String name, Pageable pageable) {
-    return userRetriever.findAllByGenerationAndPartAndName(generation, part, name, pageable);
+  public Page<User> findAllByGenerationAndPartAndNameAndTeam(
+      Integer generation, Part part, String name, Team team, Pageable pageable) {
+    return userRetriever.findAllByGenerationAndPartAndNameAndTeam(
+        generation, part, name, team, pageable);
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
@@ -9,6 +9,8 @@ import sopt.makers.authentication.domain.user.User;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,8 +73,9 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
-  public List<User> findAllByGenerationAndPart(Integer generation, Part part) {
-    return userRetriever.findAllByActivity(generation, part);
+  public Page<User> findAllByGenerationAndPartAndName(
+      Integer generation, Part part, String name, Pageable pageable) {
+    return userRetriever.findAllByGenerationAndPartAndName(generation, part, name, pageable);
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
@@ -12,6 +12,8 @@ import sopt.makers.authentication.domain.user.exception.UserException;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -49,11 +51,13 @@ public class UserRetriever {
     return userJpaRepository.existsByPhone(phone);
   }
 
-  public List<User> findAllByActivity(Integer generation, Part part) {
-    List<UserEntity> userEntityList =
-        userJpaRepository.findAllWithActivityHistoriesByGenerationAndPart(generation, part);
+  public Page<User> findAllByGenerationAndPartAndName(
+      Integer generation, Part part, String name, Pageable pageable) {
+    Page<UserEntity> userEntityPage =
+        userJpaRepository.findAllWithActivityHistoriesByGenerationAndPartAndName(
+            generation, part, name, pageable);
 
-    return userEntityList.stream().map(UserEntity::toDomain).toList();
+    return userEntityPage.map(UserEntity::toDomain);
   }
 
   public int countByGeneration(int generation) {

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
@@ -7,6 +7,7 @@ import sopt.makers.authentication.adapter.out.persistence.entity.UserEntity;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.auth.exception.AuthException;
 import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.exception.UserException;
 
@@ -51,11 +52,11 @@ public class UserRetriever {
     return userJpaRepository.existsByPhone(phone);
   }
 
-  public Page<User> findAllByGenerationAndPartAndName(
-      Integer generation, Part part, String name, Pageable pageable) {
+  public Page<User> findAllByGenerationAndPartAndNameAndTeam(
+      Integer generation, Part part, String name, Team team, Pageable pageable) {
     Page<UserEntity> userEntityPage =
-        userJpaRepository.findAllWithActivityHistoriesByGenerationAndPartAndName(
-            generation, part, name, pageable);
+        userJpaRepository.findAllWithActivityHistoriesByGenerationAndPartAndNameAndTeam(
+            generation, part, name, team, pageable);
 
     return userEntityPage.map(UserEntity::toDomain);
   }

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -6,6 +6,7 @@ import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.domain.user.UserOrderBy;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,7 +16,13 @@ public interface GetUserProfileUsecase {
   List<UserProfileAndActivityInfo> getUserInformation(List<Long> userIds);
 
   PaginatedUserProfiles getUserInformationByFilters(
-      Integer generation, Part part, String name, Team team, int offset, int limit);
+      Integer generation,
+      Part part,
+      String name,
+      Team team,
+      int offset,
+      int limit,
+      UserOrderBy orderBy);
 
   UserCountByGeneration getUserCountByGeneration(int generation);
 

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -13,7 +13,8 @@ public interface GetUserProfileUsecase {
 
   List<UserProfileAndActivityInfo> getUserInformation(List<Long> userIds);
 
-  List<UserProfileAndActivityInfo> getUserInformationByActivity(Integer generation, Part part);
+  PaginatedUserProfiles getUserInformationByFilters(
+      Integer generation, Part part, String name, Integer offset, Integer limit);
 
   UserCountByGeneration getUserCountByGeneration(int generation);
 
@@ -55,4 +56,7 @@ public interface GetUserProfileUsecase {
   }
 
   record UserCountByGeneration(int count) {}
+
+  record PaginatedUserProfiles(
+      List<UserProfileAndActivityInfo> profiles, boolean hasNext, int totalCount) {}
 }

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -15,7 +15,7 @@ public interface GetUserProfileUsecase {
   List<UserProfileAndActivityInfo> getUserInformation(List<Long> userIds);
 
   PaginatedUserProfiles getUserInformationByFilters(
-      Integer generation, Part part, String name, Team team, Integer offset, Integer limit);
+      Integer generation, Part part, String name, Team team, int offset, int limit);
 
   UserCountByGeneration getUserCountByGeneration(int generation);
 

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -59,5 +59,5 @@ public interface GetUserProfileUsecase {
   record UserCountByGeneration(int count) {}
 
   record PaginatedUserProfiles(
-      List<UserProfileAndActivityInfo> profiles, boolean hasNext, int totalCount) {}
+      List<UserProfileAndActivityInfo> profiles, boolean hasNext, long totalCount) {}
 }

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -4,6 +4,7 @@ import sopt.makers.authentication.domain.user.Activity;
 import sopt.makers.authentication.domain.user.ActivityList;
 import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Profile;
+import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
 
 import java.time.LocalDate;
@@ -14,7 +15,7 @@ public interface GetUserProfileUsecase {
   List<UserProfileAndActivityInfo> getUserInformation(List<Long> userIds);
 
   PaginatedUserProfiles getUserInformationByFilters(
-      Integer generation, Part part, String name, Integer offset, Integer limit);
+      Integer generation, Part part, String name, Team team, Integer offset, Integer limit);
 
   UserCountByGeneration getUserCountByGeneration(int generation);
 

--- a/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
@@ -3,6 +3,7 @@ package sopt.makers.authentication.application.port.out.user;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Profile;
+import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
 
 import java.util.List;
@@ -28,8 +29,8 @@ public interface UserRepository {
 
   boolean existsByPhone(String phone);
 
-  Page<User> findAllByGenerationAndPartAndName(
-      Integer generation, Part part, String name, Pageable pageable);
+  Page<User> findAllByGenerationAndPartAndNameAndTeam(
+      Integer generation, Part part, String name, Team team, Pageable pageable);
 
   int countByGeneration(int generation);
 }

--- a/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
@@ -7,6 +7,9 @@ import sopt.makers.authentication.domain.user.User;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface UserRepository {
 
   User findBySocialAccount(SocialAccount socialAccount);
@@ -25,7 +28,8 @@ public interface UserRepository {
 
   boolean existsByPhone(String phone);
 
-  List<User> findAllByGenerationAndPart(Integer generation, Part part);
+  Page<User> findAllByGenerationAndPartAndName(
+      Integer generation, Part part, String name, Pageable pageable);
 
   int countByGeneration(int generation);
 }

--- a/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
@@ -7,6 +7,10 @@ import sopt.makers.authentication.domain.user.User;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -27,12 +31,21 @@ public class GetUserProfileService implements GetUserProfileUsecase {
   }
 
   @Override
-  public List<UserProfileAndActivityInfo> getUserInformationByActivity(
-      Integer generation, Part part) {
-    List<User> userList = userRepository.findAllByGenerationAndPart(generation, part);
-    return userList.stream()
-        .map(user -> UserProfileAndActivityInfo.of(user, user.getActivities()))
-        .toList();
+  public PaginatedUserProfiles getUserInformationByFilters(
+      Integer generation, Part part, String name, Integer offset, Integer limit) {
+    Pageable pageable = PageRequest.of(offset / limit, limit, Sort.by("id").descending());
+    Page<User> userEntityPage =
+        userRepository.findAllByGenerationAndPartAndName(generation, part, name, pageable);
+
+    int totalCount = (int) userEntityPage.getTotalElements();
+    boolean hasNext = userEntityPage.hasNext();
+
+    List<UserProfileAndActivityInfo> profiles =
+        userEntityPage.getContent().stream()
+            .map(user -> UserProfileAndActivityInfo.of(user, user.getActivities()))
+            .toList();
+
+    return new PaginatedUserProfiles(profiles, hasNext, totalCount);
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
@@ -3,6 +3,7 @@ package sopt.makers.authentication.application.service.user;
 import sopt.makers.authentication.application.port.in.user.GetUserProfileUsecase;
 import sopt.makers.authentication.application.port.out.user.UserRepository;
 import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
 
 import java.util.List;
@@ -32,10 +33,11 @@ public class GetUserProfileService implements GetUserProfileUsecase {
 
   @Override
   public PaginatedUserProfiles getUserInformationByFilters(
-      Integer generation, Part part, String name, Integer offset, Integer limit) {
+      Integer generation, Part part, String name, Team team, Integer offset, Integer limit) {
     Pageable pageable = PageRequest.of(offset / limit, limit, Sort.by("id").descending());
     Page<User> userEntityPage =
-        userRepository.findAllByGenerationAndPartAndName(generation, part, name, pageable);
+        userRepository.findAllByGenerationAndPartAndNameAndTeam(
+            generation, part, name, team, pageable);
 
     int totalCount = (int) userEntityPage.getTotalElements();
     boolean hasNext = userEntityPage.hasNext();

--- a/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
@@ -5,6 +5,7 @@ import sopt.makers.authentication.application.port.out.user.UserRepository;
 import sopt.makers.authentication.domain.user.Part;
 import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
+import sopt.makers.authentication.domain.user.UserOrderBy;
 
 import java.util.List;
 
@@ -20,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GetUserProfileService implements GetUserProfileUsecase {
 
+  private static final String USER_ACTIVITY_SORT_ALIAS = "a.";
+
   private final UserRepository userRepository;
 
   @Override
@@ -33,8 +36,15 @@ public class GetUserProfileService implements GetUserProfileUsecase {
 
   @Override
   public PaginatedUserProfiles getUserInformationByFilters(
-      Integer generation, Part part, String name, Team team, int offset, int limit) {
-    Pageable pageable = PageRequest.of(offset / limit, limit, Sort.by("id").descending());
+      Integer generation,
+      Part part,
+      String name,
+      Team team,
+      int offset,
+      int limit,
+      UserOrderBy orderBy) {
+    Pageable pageable = getPageable(offset, limit, orderBy);
+
     Page<User> userEntityPage =
         userRepository.findAllByGenerationAndPartAndNameAndTeam(
             generation, part, name, team, pageable);
@@ -48,6 +58,18 @@ public class GetUserProfileService implements GetUserProfileUsecase {
             .toList();
 
     return new PaginatedUserProfiles(profiles, hasNext, totalCount);
+  }
+
+  private static Pageable getPageable(int offset, int limit, UserOrderBy orderBy) {
+    if (orderBy.isGenerationOrder()) {
+      return PageRequest.of(
+          offset / limit,
+          limit,
+          Sort.by(orderBy.getDirection(), USER_ACTIVITY_SORT_ALIAS + orderBy.getField()));
+    } else {
+      return PageRequest.of(
+          offset / limit, limit, Sort.by(orderBy.getDirection(), orderBy.getField()));
+    }
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
@@ -39,7 +39,7 @@ public class GetUserProfileService implements GetUserProfileUsecase {
         userRepository.findAllByGenerationAndPartAndNameAndTeam(
             generation, part, name, team, pageable);
 
-    int totalCount = (int) userEntityPage.getTotalElements();
+    long totalCount = userEntityPage.getTotalElements();
     boolean hasNext = userEntityPage.hasNext();
 
     List<UserProfileAndActivityInfo> profiles =

--- a/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
@@ -33,7 +33,7 @@ public class GetUserProfileService implements GetUserProfileUsecase {
 
   @Override
   public PaginatedUserProfiles getUserInformationByFilters(
-      Integer generation, Part part, String name, Team team, Integer offset, Integer limit) {
+      Integer generation, Part part, String name, Team team, int offset, int limit) {
     Pageable pageable = PageRequest.of(offset / limit, limit, Sort.by("id").descending());
     Page<User> userEntityPage =
         userRepository.findAllByGenerationAndPartAndNameAndTeam(

--- a/src/main/java/sopt/makers/authentication/application/validator/user/UserSearchConditionValidator.java
+++ b/src/main/java/sopt/makers/authentication/application/validator/user/UserSearchConditionValidator.java
@@ -3,6 +3,7 @@ package sopt.makers.authentication.application.validator.user;
 import static sopt.makers.authentication.domain.user.exception.UserFailure.BAD_REQUEST_INVALID_USER_SEARCH_CONDITION;
 
 import sopt.makers.authentication.domain.user.Part;
+import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.exception.UserException;
 
 import org.springframework.stereotype.Component;
@@ -10,8 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserSearchConditionValidator {
 
-  public void validateUserSearchCondition(Integer generation, Part part, String name) {
-    if (generation == null && part == null && name == null) {
+  public void validateUserSearchCondition(Integer generation, Part part, String name, Team team) {
+    if (generation == null && part == null && name == null && team == null) {
       throw new UserException(BAD_REQUEST_INVALID_USER_SEARCH_CONDITION);
     }
   }

--- a/src/main/java/sopt/makers/authentication/application/validator/user/UserSearchConditionValidator.java
+++ b/src/main/java/sopt/makers/authentication/application/validator/user/UserSearchConditionValidator.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserSearchConditionValidator {
 
-  public void validateUserSearchCondition(Integer generation, Part part) {
-    if (generation == null && part == null) {
+  public void validateUserSearchCondition(Integer generation, Part part, String name) {
+    if (generation == null && part == null && name == null) {
       throw new UserException(BAD_REQUEST_INVALID_USER_SEARCH_CONDITION);
     }
   }

--- a/src/main/java/sopt/makers/authentication/common/constant/PagingConstant.java
+++ b/src/main/java/sopt/makers/authentication/common/constant/PagingConstant.java
@@ -3,8 +3,8 @@ package sopt.makers.authentication.common.constant;
 public final class PagingConstant {
   private PagingConstant() {}
 
-  public static final int DEFAULT_OFFSET = 0;
-  public static final int DEFAULT_LIMIT = 30;
+  public static final String DEFAULT_OFFSET = "0";
+  public static final String DEFAULT_LIMIT = "30";
   public static final int MAX_LIMIT = 30;
   public static final String DEFAULT_ORDER_BY = "LATEST_REGISTERED";
 }

--- a/src/main/java/sopt/makers/authentication/common/constant/PagingConstant.java
+++ b/src/main/java/sopt/makers/authentication/common/constant/PagingConstant.java
@@ -1,0 +1,10 @@
+package sopt.makers.authentication.common.constant;
+
+public final class PagingConstant {
+  private PagingConstant() {}
+
+  public static final int DEFAULT_OFFSET = 0;
+  public static final int DEFAULT_LIMIT = 30;
+  public static final int MAX_LIMIT = 30;
+  public static final String DEFAULT_ORDER_BY = "LATEST_REGISTERED";
+}

--- a/src/main/java/sopt/makers/authentication/domain/user/UserOrderBy.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/UserOrderBy.java
@@ -1,0 +1,25 @@
+package sopt.makers.authentication.domain.user;
+
+import org.springframework.data.domain.Sort;
+
+import lombok.Getter;
+
+@Getter
+public enum UserOrderBy {
+  LATEST_REGISTERED("id", Sort.Direction.DESC),
+  OLDEST_REGISTERED("id", Sort.Direction.ASC),
+  LATEST_GENERATION("generation", Sort.Direction.DESC),
+  OLDEST_GENERATION("generation", Sort.Direction.ASC);
+
+  private final String field;
+  private final Sort.Direction direction;
+
+  UserOrderBy(String field, Sort.Direction direction) {
+    this.field = field;
+    this.direction = direction;
+  }
+
+  public boolean isGenerationOrder() {
+    return this == LATEST_GENERATION || this == OLDEST_GENERATION;
+  }
+}


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #135 

## Work Description ✏️
1. 유저 조회 API에 name, team 조건을 추가했습니다
2. offset 기반 페이지네이션도 추가했어요. 플그에서 내부적으로 요청할 때 offset 기반 페이지네이션을 사용하고 있어서 동일하게 구현했습니다. 후에 플그에 커서 기반 페이지네이션으로 수정 요청할 예정이에요. 
3. UserOrderBy 정렬 조건 4가지를 추가했습니다. 
- `LATEST_REGISTERED` (기본값): **최신 등록순** (user id 내림차순)
- `OLDEST_REGISTERED`: **오래된 등록순** (user id 오름차순)
- `LATEST_GENERATION`: **최신 활동기수 순**
- `OLDEST_GENERATION`: **오래된 활동기수 순**
4. pagingConstant 파일을 추가해서 공통 상수를 관리하도록 했어요
5. 플그에서 받은 params을 검증하도록 했어요 (최대, 최소 설정)

(dev에 코드가 반영되면 API 명세도 변경해두겠습니다~)

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 오프셋 기반으로 구현하다보니 메모리 사용량이 커질 수 있다는 경고가 발생하고 있는 상황이에요. 이 부분은 추후에 플그와 방식을 맞추면서 개선할 수 있을 것 같습니다. 
