### PR TITLE
[FEAT/#140] hasProfile 필드 추가

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
@@ -18,6 +18,7 @@ public final class UserResponse {
       LocalDate birthday,
       String phone,
       String email,
+      boolean hasProfile,
       Integer lastGeneration,
       List<UserActivityDetail> soptActivities) {
     public static UserProfileAndActivity from(
@@ -34,6 +35,7 @@ public final class UserResponse {
           userProfileAndActivityInfo.birthday(),
           userProfileAndActivityInfo.phone(),
           userProfileAndActivityInfo.email(),
+          userProfileAndActivityInfo.hasProfile(),
           userProfileAndActivityInfo.lastGeneration(),
           soptActivities);
     }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
@@ -39,6 +39,7 @@ public class UserEntity extends BaseEntity {
   private LocalDate birthday;
   @NotNull private String authPlatformId;
   private String profileImage;
+  @NotNull private boolean hasProfile;
 
   @NotNull
   @Enumerated(EnumType.STRING)
@@ -54,7 +55,8 @@ public class UserEntity extends BaseEntity {
       LocalDate birthday,
       String profileImage,
       String authPlatformId,
-      AuthPlatform authPlatformType) {
+      AuthPlatform authPlatformType,
+      boolean hasProfile) {
     super();
     this.name = name;
     this.phone = phone;
@@ -63,6 +65,7 @@ public class UserEntity extends BaseEntity {
     this.profileImage = profileImage;
     this.authPlatformId = authPlatformId;
     this.authPlatformType = authPlatformType;
+    this.hasProfile = hasProfile;
   }
 
   public static UserEntity fromDomain(final User user) {
@@ -77,7 +80,8 @@ public class UserEntity extends BaseEntity {
             profile.birthday(),
             profile.profileImage().orElse(null),
             socialAccount.authPlatformId(),
-            socialAccount.authPlatformType());
+            socialAccount.authPlatformType(),
+            profile.hasProfile());
     if (hasId) {
       userEntity.setId(user.getId());
     }
@@ -86,7 +90,7 @@ public class UserEntity extends BaseEntity {
 
   public User toDomain() {
     SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType);
-    Profile profile = Profile.of(name, email, phone, birthday, profileImage);
+    Profile profile = Profile.of(name, email, phone, birthday, profileImage, hasProfile);
     if (userActivityHistoryList == null || userActivityHistoryList.isEmpty()) {
       return User.createUser(super.getId(), socialAccount, profile);
     }

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -33,6 +33,7 @@ public interface GetUserProfileUsecase {
       LocalDate birthday,
       String phone,
       String email,
+      boolean hasProfile,
       Integer lastGeneration,
       List<UserActivityinfo> soptActivities) {
 
@@ -48,6 +49,7 @@ public interface GetUserProfileUsecase {
           profile.birthday(),
           profile.phone(),
           profile.email().orElse(null),
+          profile.hasProfile(),
           activities.getLastActivity().getGeneration(),
           userActivityinfos);
     }

--- a/src/main/java/sopt/makers/authentication/domain/user/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Profile.java
@@ -43,39 +43,4 @@ public record Profile(
         Optional.ofNullable(profileImage),
         true);
   }
-
-  public Profile updateName(final String name) {
-    return new Profile(
-        name, this.email, this.phone, this.birthday, this.profileImage, this.hasProfile);
-  }
-
-  public Profile updateEmail(final String email) {
-    return new Profile(
-        this.name,
-        Optional.ofNullable(email),
-        this.phone,
-        this.birthday,
-        this.profileImage,
-        this.hasProfile);
-  }
-
-  public Profile updatePhone(final String phone) {
-    return new Profile(
-        this.name, this.email, phone, this.birthday, this.profileImage, this.hasProfile);
-  }
-
-  public Profile updateBirthday(final LocalDate birthday) {
-    return new Profile(
-        this.name, this.email, this.phone, birthday, this.profileImage, this.hasProfile);
-  }
-
-  public Profile updateProfileImage(final String profileImage) {
-    return new Profile(
-        this.name,
-        this.email,
-        this.phone,
-        this.birthday,
-        Optional.ofNullable(profileImage),
-        this.hasProfile);
-  }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Profile.java
@@ -10,43 +10,72 @@ public record Profile(
     Optional<String> email,
     @NotNull String phone,
     @NotNull LocalDate birthday,
-    Optional<String> profileImage) {
+    Optional<String> profileImage,
+    @NotNull boolean hasProfile) {
 
   public static Profile of(String name, String email, String phone, LocalDate birthday) {
-    return new Profile(name, Optional.ofNullable(email), phone, birthday, Optional.empty());
+    return new Profile(name, Optional.ofNullable(email), phone, birthday, Optional.empty(), false);
   }
 
   public static Profile of(
-      String name, String email, String phone, LocalDate birthday, String profileImage) {
+      String name,
+      String email,
+      String phone,
+      LocalDate birthday,
+      String profileImage,
+      boolean hasProfile) {
     return new Profile(
-        name, Optional.ofNullable(email), phone, birthday, Optional.ofNullable(profileImage));
+        name,
+        Optional.ofNullable(email),
+        phone,
+        birthday,
+        Optional.ofNullable(profileImage),
+        hasProfile);
   }
 
   public Profile updateProfile(
       String email, String phone, LocalDate birthday, String profileImage) {
     return new Profile(
-        this.name, Optional.ofNullable(email), phone, birthday, Optional.ofNullable(profileImage));
+        this.name,
+        Optional.ofNullable(email),
+        phone,
+        birthday,
+        Optional.ofNullable(profileImage),
+        true);
   }
 
   public Profile updateName(final String name) {
-    return new Profile(name, this.email, this.phone, this.birthday, this.profileImage);
+    return new Profile(
+        name, this.email, this.phone, this.birthday, this.profileImage, this.hasProfile);
   }
 
   public Profile updateEmail(final String email) {
     return new Profile(
-        this.name, Optional.ofNullable(email), this.phone, this.birthday, this.profileImage);
+        this.name,
+        Optional.ofNullable(email),
+        this.phone,
+        this.birthday,
+        this.profileImage,
+        this.hasProfile);
   }
 
   public Profile updatePhone(final String phone) {
-    return new Profile(this.name, this.email, phone, this.birthday, this.profileImage);
+    return new Profile(
+        this.name, this.email, phone, this.birthday, this.profileImage, this.hasProfile);
   }
 
   public Profile updateBirthday(final LocalDate birthday) {
-    return new Profile(this.name, this.email, this.phone, birthday, this.profileImage);
+    return new Profile(
+        this.name, this.email, this.phone, birthday, this.profileImage, this.hasProfile);
   }
 
   public Profile updateProfileImage(final String profileImage) {
     return new Profile(
-        this.name, this.email, this.phone, this.birthday, Optional.ofNullable(profileImage));
+        this.name,
+        this.email,
+        this.phone,
+        this.birthday,
+        Optional.ofNullable(profileImage),
+        this.hasProfile);
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #140 

## Work Description ✏️
- 회원가입 시엔 hasProfile 필드가 `false`로 설정되도록 구현했습니다.
- 정보 수정 시엔 hasProfile 필드가 `true`로 설정되도록 구현했습니다. 
- DB user table에 has_profile 필드를 추가했습니다. 
- 유저조회 API 응답에 hasProfile 필드를 추가했습니다. 

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- PROD에 있는 기존 사용자들은 hasProfile을 true로 업데이트하는 게 좋을까요? 혹시 따로 프로필 생성 여부를 확인할 수 있는 로직이 있을까요? 
- 확인할 수 있는 로직이 없다면, 모두 true로 업데이트해도 좋을 것 같습니다! 