### PR TITLE
[FIX/#145] 토큰 리프레시 시 Access token이 만료되어도 재발급 가능하도록 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/out/jwt/decoder/LenientJwtDecoder.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/jwt/decoder/LenientJwtDecoder.java
@@ -1,0 +1,5 @@
+package sopt.makers.authentication.adapter.out.jwt.decoder;
+
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+public interface LenientJwtDecoder extends JwtDecoder {}

--- a/src/main/java/sopt/makers/authentication/adapter/out/jwt/service/JwtAuthAccessTokenService.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/jwt/service/JwtAuthAccessTokenService.java
@@ -4,6 +4,7 @@ import static sopt.makers.authentication.adapter.out.jwt.provider.JwtTokenUtil.e
 
 import sopt.makers.authentication.adapter.in.web.security.authentication.CustomAuthentication;
 import sopt.makers.authentication.adapter.out.jwt.JwtProvider;
+import sopt.makers.authentication.adapter.out.jwt.decoder.LenientJwtDecoder;
 import sopt.makers.authentication.adapter.out.jwt.token.JwtAccessToken;
 import sopt.makers.authentication.config.SecurityProperty;
 
@@ -28,6 +29,7 @@ public class JwtAuthAccessTokenService implements JwtProvider<CustomAuthenticati
   private final JwtEncoder jwtEncoder;
   private final JwtDecoder jwtDecoder;
   private final SecurityProperty securityProperty;
+  private final LenientJwtDecoder lenientJwtDecoder;
 
   @Override
   public String generateJwt(CustomAuthentication authentication) {
@@ -74,6 +76,13 @@ public class JwtAuthAccessTokenService implements JwtProvider<CustomAuthenticati
   public CustomAuthentication parse(String requestToken) {
     String token = extract(requestToken);
     Jwt accessToken = jwtDecoder.decode(token);
+    JwtAccessToken jwtAccessToken = JwtAccessToken.createJwtAccessToken(accessToken);
+    return jwtAccessToken.parse();
+  }
+
+  public CustomAuthentication parseLenient(String requestToken) {
+    String token = extract(requestToken);
+    Jwt accessToken = lenientJwtDecoder.decode(token);
     JwtAccessToken jwtAccessToken = JwtAccessToken.createJwtAccessToken(accessToken);
     return jwtAccessToken.parse();
   }

--- a/src/main/java/sopt/makers/authentication/adapter/out/jwt/service/JwtAuthRefreshTokenService.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/jwt/service/JwtAuthRefreshTokenService.java
@@ -39,15 +39,7 @@ public class JwtAuthRefreshTokenService implements JwtProvider<String> {
 
     JwtRefreshToken jwtRefreshToken = JwtRefreshToken.createRefreshToken(jwt);
     jwtRefreshToken.validateExpire();
-    JwtRefreshToken refreshedToken = refresh();
-
-    return refreshedToken.getToken();
-  }
-
-  private JwtRefreshToken refresh() {
-    JwtClaimsSet claimsSet = generateClaimSet();
-    Jwt jwt = jwtEncoder.encode(JwtEncoderParameters.from(claimsSet));
-    return JwtRefreshToken.createRefreshToken(jwt);
+    return jwtRefreshToken.getToken();
   }
 
   private JwtClaimsSet generateClaimSet() {

--- a/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
@@ -50,7 +50,7 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
 
     jwtAuthRefreshTokenProvider.parse(refreshToken);
     CustomAuthentication customAuthentication =
-        jwtAuthAccessTokenProvider.parse(command.accessToken());
+        jwtAuthAccessTokenProvider.parseLenient(command.accessToken());
 
     String renewedAccessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
     String renewedRefreshToken = jwtAuthRefreshTokenProvider.generateJwt(renewedAccessToken);

--- a/src/main/java/sopt/makers/authentication/config/JwtRSAKeyConfiguration.java
+++ b/src/main/java/sopt/makers/authentication/config/JwtRSAKeyConfiguration.java
@@ -1,5 +1,6 @@
 package sopt.makers.authentication.config;
 
+import sopt.makers.authentication.adapter.out.jwt.decoder.LenientJwtDecoder;
 import sopt.makers.authentication.application.port.out.auth.RSAKeyManager;
 
 import java.security.interfaces.RSAPrivateKey;
@@ -7,8 +8,11 @@ import java.security.interfaces.RSAPublicKey;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 
@@ -41,5 +45,17 @@ public class JwtRSAKeyConfiguration {
   @Bean
   public JwtDecoder jwtDecoder() {
     return NimbusJwtDecoder.withPublicKey(keyManager.getPublicKey()).build();
+  }
+
+  @Bean
+  public LenientJwtDecoder lenientJwtDecoder() {
+    NimbusJwtDecoder decoder = NimbusJwtDecoder.withPublicKey(keyManager.getPublicKey()).build();
+
+    String issuer = securityProperty.jwt().secret().issuer().issuerName();
+
+    OAuth2TokenValidator<Jwt> onlyIssuer = new JwtIssuerValidator(issuer);
+    decoder.setJwtValidator(onlyIssuer);
+
+    return decoder::decode;
   }
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #145

## Work Description ✏️
- 기존에는 exp 까지 검증하고 있어서 오류가 발생했었습니다. 
- Refresh 요청 시 Access token에 대해서는 issue만 검증하도록 수정했습니다.
- issue만 검증하는 LenientJwtDecoder를 생성하여, refresh 요청 시에는 issue 검증만 하도록 수정했습니다. 

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
