### PR TITLE
[FIX] AuthApi interface 어노테이션 불일치 문제 해결을 위해 어노테이션 삭제

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/auth/AuthApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/auth/AuthApi.java
@@ -4,7 +4,6 @@ import sopt.makers.authentication.adapter.in.web.common.BaseResponse;
 import sopt.makers.authentication.adapter.in.web.dto.auth.request.AuthRequest;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 public interface AuthApi {
 
@@ -23,9 +22,7 @@ public interface AuthApi {
   ResponseEntity<BaseResponse<?>> refreshTokenFromApp(
       AuthRequest.AuthenticationTokenInfo authenticationTokenInfo);
 
-  ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(
-      @RequestHeader("accessToken") String accessToken,
-      @RequestHeader("refreshToken") String refreshToken);
+  ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(String accessToken, String refreshToken);
 
   ResponseEntity<BaseResponse<?>> signUp(AuthRequest.SignUpInfo signUp);
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #151

## Work Description ✏️
- controller 클래스의 인터페이스인 AuthApi에도 중복적으로 어노테이션이 붙어있어 @CookieValue가 아닌 header로 인식되는 문제 수정

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
