### PR TITLE
[FEAT/#153] 사용자가 처음 로그인하는지의 여부를 반환하는 로직 구현 및 hasProfile 로직 삭제

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/auth/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/auth/AuthApiController.java
@@ -65,7 +65,7 @@ public class AuthApiController implements AuthApi {
         AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
         headers,
         AuthResponse.AuthenticateSocialAuthInfoForWeb.of(
-            tokenInfo.accessToken(), tokenInfo.hasProfile()));
+            tokenInfo.accessToken(), tokenInfo.isFirstLogin()));
   }
 
   @Override
@@ -78,7 +78,7 @@ public class AuthApiController implements AuthApi {
     return ResponseUtil.success(
         AuthSuccess.AUTHENTICATE_SOCIAL_ACCOUNT,
         AuthResponse.AuthenticateSocialAuthInfoForApp.of(
-            tokenInfo.accessToken(), tokenInfo.refreshToken(), tokenInfo.hasProfile()));
+            tokenInfo.accessToken(), tokenInfo.refreshToken(), tokenInfo.isFirstLogin()));
   }
 
   @PostMapping("/signup")

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/dto/auth/response/AuthResponse.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/dto/auth/response/AuthResponse.java
@@ -20,17 +20,18 @@ public final class AuthResponse {
     }
   }
 
-  public record AuthenticateSocialAuthInfoForWeb(String accessToken, boolean hasProfile) {
-    public static AuthenticateSocialAuthInfoForWeb of(String accessToken, boolean hasProfile) {
-      return new AuthenticateSocialAuthInfoForWeb(accessToken, hasProfile);
+  public record AuthenticateSocialAuthInfoForWeb(
+      String accessToken, @JsonProperty("isFirstLogin") boolean isFirstLogin) {
+    public static AuthenticateSocialAuthInfoForWeb of(String accessToken, boolean isFirstLogin) {
+      return new AuthenticateSocialAuthInfoForWeb(accessToken, isFirstLogin);
     }
   }
 
   public record AuthenticateSocialAuthInfoForApp(
-      String accessToken, String refreshToken, boolean hasProfile) {
+      String accessToken, String refreshToken, @JsonProperty("isFirstLogin") boolean isFirstLogin) {
     public static AuthenticateSocialAuthInfoForApp of(
-        String accessToken, String refreshToken, boolean hasProfile) {
-      return new AuthenticateSocialAuthInfoForApp(accessToken, refreshToken, hasProfile);
+        String accessToken, String refreshToken, boolean isFirstLogin) {
+      return new AuthenticateSocialAuthInfoForApp(accessToken, refreshToken, isFirstLogin);
     }
   }
 

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
@@ -18,7 +18,6 @@ public final class UserResponse {
       LocalDate birthday,
       String phone,
       String email,
-      boolean hasProfile,
       Integer lastGeneration,
       List<UserActivityDetail> soptActivities) {
     public static UserProfileAndActivity from(
@@ -35,7 +34,6 @@ public final class UserResponse {
           userProfileAndActivityInfo.birthday(),
           userProfileAndActivityInfo.phone(),
           userProfileAndActivityInfo.email(),
-          userProfileAndActivityInfo.hasProfile(),
           userProfileAndActivityInfo.lastGeneration(),
           soptActivities);
     }

--- a/src/main/java/sopt/makers/authentication/adapter/out/cache/mapper/UserMapper.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/cache/mapper/UserMapper.java
@@ -46,13 +46,12 @@ public class UserMapper {
             cached.email(),
             cached.phone(),
             cached.birthday(),
-            cached.profileImage(),
-            true);
+            cached.profileImage());
 
     List<Activity> activities = cached.activities().stream().map(this::toActivity).toList();
     ActivityList activityList = ActivityList.of(activities);
 
-    return User.createUser(cached.userId(), null, profile, activityList);
+    return User.createUser(cached.userId(), null, profile, activityList, false);
   }
 
   public Activity toActivity(CachedUserActivity cached) {

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
@@ -92,7 +92,7 @@ public class UserEntity extends BaseEntity {
     SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType);
     Profile profile = Profile.of(name, email, phone, birthday, profileImage);
     if (userActivityHistoryList == null || userActivityHistoryList.isEmpty()) {
-      return User.createUser(super.getId(), socialAccount, profile);
+      return User.createUser(super.getId(), socialAccount, profile, isFirstLogin);
     }
     List<Activity> activityList =
         userActivityHistoryList.stream().map(UserActivityHistoryEntity::toDomain).toList();

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
@@ -81,7 +81,7 @@ public class UserEntity extends BaseEntity {
             profile.profileImage().orElse(null),
             socialAccount.authPlatformId(),
             socialAccount.authPlatformType(),
-            profile.isFirstLogin());
+            user.isFirstLogin());
     if (hasId) {
       userEntity.setId(user.getId());
     }
@@ -90,12 +90,13 @@ public class UserEntity extends BaseEntity {
 
   public User toDomain() {
     SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType);
-    Profile profile = Profile.of(name, email, phone, birthday, profileImage, isFirstLogin);
+    Profile profile = Profile.of(name, email, phone, birthday, profileImage);
     if (userActivityHistoryList == null || userActivityHistoryList.isEmpty()) {
       return User.createUser(super.getId(), socialAccount, profile);
     }
     List<Activity> activityList =
         userActivityHistoryList.stream().map(UserActivityHistoryEntity::toDomain).toList();
-    return User.createUser(super.getId(), socialAccount, profile, ActivityList.of(activityList));
+    return User.createUser(
+        super.getId(), socialAccount, profile, ActivityList.of(activityList), isFirstLogin);
   }
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserEntity.java
@@ -39,7 +39,7 @@ public class UserEntity extends BaseEntity {
   private LocalDate birthday;
   @NotNull private String authPlatformId;
   private String profileImage;
-  @NotNull private boolean hasProfile;
+  private boolean isFirstLogin;
 
   @NotNull
   @Enumerated(EnumType.STRING)
@@ -56,7 +56,7 @@ public class UserEntity extends BaseEntity {
       String profileImage,
       String authPlatformId,
       AuthPlatform authPlatformType,
-      boolean hasProfile) {
+      boolean isFirstLogin) {
     super();
     this.name = name;
     this.phone = phone;
@@ -65,7 +65,7 @@ public class UserEntity extends BaseEntity {
     this.profileImage = profileImage;
     this.authPlatformId = authPlatformId;
     this.authPlatformType = authPlatformType;
-    this.hasProfile = hasProfile;
+    this.isFirstLogin = isFirstLogin;
   }
 
   public static UserEntity fromDomain(final User user) {
@@ -81,7 +81,7 @@ public class UserEntity extends BaseEntity {
             profile.profileImage().orElse(null),
             socialAccount.authPlatformId(),
             socialAccount.authPlatformType(),
-            profile.hasProfile());
+            profile.isFirstLogin());
     if (hasId) {
       userEntity.setId(user.getId());
     }
@@ -90,7 +90,7 @@ public class UserEntity extends BaseEntity {
 
   public User toDomain() {
     SocialAccount socialAccount = SocialAccount.of(authPlatformId, authPlatformType);
-    Profile profile = Profile.of(name, email, phone, birthday, profileImage, hasProfile);
+    Profile profile = Profile.of(name, email, phone, birthday, profileImage, isFirstLogin);
     if (userActivityHistoryList == null || userActivityHistoryList.isEmpty()) {
       return User.createUser(super.getId(), socialAccount, profile);
     }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
@@ -73,6 +73,13 @@ public class UserRepositoryImpl implements UserRepository {
     userRegister.save(userEntity);
   }
 
+  @Transactional
+  @Override
+  public void update(User user) {
+    UserEntity userEntity = UserEntity.fromDomain(user);
+    userRegister.save(userEntity);
+  }
+
   @Override
   public boolean existsByPhone(String phone) {
     return userRetriever.existsByPhone(phone);

--- a/src/main/java/sopt/makers/authentication/application/port/in/auth/AuthenticateSocialAccountUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/auth/AuthenticateSocialAccountUsecase.java
@@ -13,10 +13,11 @@ public interface AuthenticateSocialAccountUsecase {
     }
   }
 
-  record AuthenticateSocialTokenInfo(String accessToken, String refreshToken, boolean hasProfile) {
+  record AuthenticateSocialTokenInfo(
+      String accessToken, String refreshToken, boolean isFirstLogin) {
     public static AuthenticateSocialTokenInfo of(
-        String accessToken, String refreshToken, boolean hasProfile) {
-      return new AuthenticateSocialTokenInfo(accessToken, refreshToken, hasProfile);
+        String accessToken, String refreshToken, boolean isFirstLogin) {
+      return new AuthenticateSocialTokenInfo(accessToken, refreshToken, isFirstLogin);
     }
   }
 

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -33,7 +33,6 @@ public interface GetUserProfileUsecase {
       LocalDate birthday,
       String phone,
       String email,
-      boolean hasProfile,
       Integer lastGeneration,
       List<UserActivityInfo> soptActivities) {
 
@@ -49,7 +48,6 @@ public interface GetUserProfileUsecase {
           profile.birthday(),
           profile.phone(),
           profile.email().orElse(null),
-          profile.hasProfile(),
           activities.getLastActivity().getGeneration(),
           userActivityInfos);
     }

--- a/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
@@ -29,6 +29,8 @@ public interface UserRepository {
 
   void update(User user, Profile profile);
 
+  void update(User user);
+
   boolean existsByPhone(String phone);
 
   Page<User> findAllByGenerationAndPartAndNameAndTeam(

--- a/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
@@ -42,7 +42,7 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
     String refreshToken = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
 
     return AuthenticateSocialTokenInfo.of(
-        accessToken, refreshToken, user.getProfile().hasProfile());
+        accessToken, refreshToken, user.getProfile().isFirstLogin());
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
@@ -8,6 +8,7 @@ import sopt.makers.authentication.application.port.out.auth.OAuthAuthenticator;
 import sopt.makers.authentication.application.port.out.user.UserRepository;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.user.ActivityList;
+import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.Role;
 import sopt.makers.authentication.domain.user.User;
 
@@ -40,9 +41,22 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
             user.getId(), null, List.of(new SimpleGrantedAuthority(role.name())));
     String accessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
     String refreshToken = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
+    boolean isFirstLoginUser = user.getProfile().isFirstLogin();
 
-    return AuthenticateSocialTokenInfo.of(
-        accessToken, refreshToken, user.getProfile().isFirstLogin());
+    if (isFirstLoginUser) {
+      Profile profile = user.getProfile();
+      Profile updatedProfile =
+          profile.updateProfile(
+              profile.email().orElse(null),
+              profile.phone(),
+              profile.birthday(),
+              profile.profileImage().orElse(null),
+              false);
+      userRepository.update(user, updatedProfile);
+      return AuthenticateSocialTokenInfo.of(accessToken, refreshToken, true);
+    }
+
+    return AuthenticateSocialTokenInfo.of(accessToken, refreshToken, false);
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
@@ -41,9 +41,9 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
             user.getId(), null, List.of(new SimpleGrantedAuthority(role.name())));
     String accessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
     String refreshToken = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
-    boolean isFirstLoginUser = user.getProfile().isFirstLogin();
+    boolean isFirstLogin = user.getProfile().isFirstLogin();
 
-    if (isFirstLoginUser) {
+    if (isFirstLogin) {
       Profile profile = user.getProfile();
       Profile updatedProfile =
           profile.updateProfile(
@@ -53,10 +53,9 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
               profile.profileImage().orElse(null),
               false);
       userRepository.update(user, updatedProfile);
-      return AuthenticateSocialTokenInfo.of(accessToken, refreshToken, true);
     }
 
-    return AuthenticateSocialTokenInfo.of(accessToken, refreshToken, false);
+    return AuthenticateSocialTokenInfo.of(accessToken, refreshToken, isFirstLogin);
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/AuthenticateSocialAccountService.java
@@ -8,7 +8,6 @@ import sopt.makers.authentication.application.port.out.auth.OAuthAuthenticator;
 import sopt.makers.authentication.application.port.out.user.UserRepository;
 import sopt.makers.authentication.domain.auth.SocialAccount;
 import sopt.makers.authentication.domain.user.ActivityList;
-import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.Role;
 import sopt.makers.authentication.domain.user.User;
 
@@ -41,18 +40,11 @@ public class AuthenticateSocialAccountService implements AuthenticateSocialAccou
             user.getId(), null, List.of(new SimpleGrantedAuthority(role.name())));
     String accessToken = jwtAuthAccessTokenProvider.generateJwt(customAuthentication);
     String refreshToken = jwtAuthRefreshTokenProvider.generateJwt(accessToken);
-    boolean isFirstLogin = user.getProfile().isFirstLogin();
+    boolean isFirstLogin = user.isFirstLogin();
 
     if (isFirstLogin) {
-      Profile profile = user.getProfile();
-      Profile updatedProfile =
-          profile.updateProfile(
-              profile.email().orElse(null),
-              profile.phone(),
-              profile.birthday(),
-              profile.profileImage().orElse(null),
-              false);
-      userRepository.update(user, updatedProfile);
+      User updatedUser = user.updateIsFirstLogin();
+      userRepository.update(updatedUser);
     }
 
     return AuthenticateSocialTokenInfo.of(accessToken, refreshToken, isFirstLogin);

--- a/src/main/java/sopt/makers/authentication/application/service/user/UpdateUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/UpdateUserProfileService.java
@@ -57,11 +57,7 @@ public class UpdateUserProfileService implements UpdateUserProfileUsecase {
     Profile profile = user.getProfile();
     Profile updatedProfile =
         profile.updateProfile(
-            command.email(),
-            command.phone(),
-            command.birthday(),
-            command.profileImage(),
-            profile.isFirstLogin());
+            command.email(), command.phone(), command.birthday(), command.profileImage());
     userRepository.update(user, updatedProfile);
     return updatedProfile;
   }
@@ -75,7 +71,12 @@ public class UpdateUserProfileService implements UpdateUserProfileUsecase {
 
   private void updateUserCache(User user, Profile updatedProfile, ActivityList updatedActivities) {
     User updatedUser =
-        User.createUser(user.getId(), user.getSocialAccount(), updatedProfile, updatedActivities);
+        User.createUser(
+            user.getId(),
+            user.getSocialAccount(),
+            updatedProfile,
+            updatedActivities,
+            user.isFirstLogin());
     userCacheRepository.put(updatedUser);
   }
 

--- a/src/main/java/sopt/makers/authentication/application/service/user/UpdateUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/UpdateUserProfileService.java
@@ -54,10 +54,14 @@ public class UpdateUserProfileService implements UpdateUserProfileUsecase {
   }
 
   private Profile updateUserProfile(User user, UserProfileCommand command) {
+    Profile profile = user.getProfile();
     Profile updatedProfile =
-        user.getProfile()
-            .updateProfile(
-                command.email(), command.phone(), command.birthday(), command.profileImage());
+        profile.updateProfile(
+            command.email(),
+            command.phone(),
+            command.birthday(),
+            command.profileImage(),
+            profile.isFirstLogin());
     userRepository.update(user, updatedProfile);
     return updatedProfile;
   }

--- a/src/main/java/sopt/makers/authentication/domain/user/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Profile.java
@@ -34,13 +34,13 @@ public record Profile(
   }
 
   public Profile updateProfile(
-      String email, String phone, LocalDate birthday, String profileImage) {
+      String email, String phone, LocalDate birthday, String profileImage, boolean isFirstLogin) {
     return new Profile(
         this.name,
         Optional.ofNullable(email),
         phone,
         birthday,
         Optional.ofNullable(profileImage),
-        this.isFirstLogin);
+        isFirstLogin);
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Profile.java
@@ -10,37 +10,21 @@ public record Profile(
     Optional<String> email,
     @NotNull String phone,
     @NotNull LocalDate birthday,
-    Optional<String> profileImage,
-    boolean isFirstLogin) {
+    Optional<String> profileImage) {
 
   public static Profile of(String name, String email, String phone, LocalDate birthday) {
-    return new Profile(name, Optional.ofNullable(email), phone, birthday, Optional.empty(), true);
+    return new Profile(name, Optional.ofNullable(email), phone, birthday, Optional.empty());
   }
 
   public static Profile of(
-      String name,
-      String email,
-      String phone,
-      LocalDate birthday,
-      String profileImage,
-      boolean isFirstLogin) {
+      String name, String email, String phone, LocalDate birthday, String profileImage) {
     return new Profile(
-        name,
-        Optional.ofNullable(email),
-        phone,
-        birthday,
-        Optional.ofNullable(profileImage),
-        isFirstLogin);
+        name, Optional.ofNullable(email), phone, birthday, Optional.ofNullable(profileImage));
   }
 
   public Profile updateProfile(
-      String email, String phone, LocalDate birthday, String profileImage, boolean isFirstLogin) {
+      String email, String phone, LocalDate birthday, String profileImage) {
     return new Profile(
-        this.name,
-        Optional.ofNullable(email),
-        phone,
-        birthday,
-        Optional.ofNullable(profileImage),
-        isFirstLogin);
+        this.name, Optional.ofNullable(email), phone, birthday, Optional.ofNullable(profileImage));
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/Profile.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Profile.java
@@ -11,10 +11,10 @@ public record Profile(
     @NotNull String phone,
     @NotNull LocalDate birthday,
     Optional<String> profileImage,
-    @NotNull boolean hasProfile) {
+    boolean isFirstLogin) {
 
   public static Profile of(String name, String email, String phone, LocalDate birthday) {
-    return new Profile(name, Optional.ofNullable(email), phone, birthday, Optional.empty(), false);
+    return new Profile(name, Optional.ofNullable(email), phone, birthday, Optional.empty(), true);
   }
 
   public static Profile of(
@@ -23,14 +23,14 @@ public record Profile(
       String phone,
       LocalDate birthday,
       String profileImage,
-      boolean hasProfile) {
+      boolean isFirstLogin) {
     return new Profile(
         name,
         Optional.ofNullable(email),
         phone,
         birthday,
         Optional.ofNullable(profileImage),
-        hasProfile);
+        isFirstLogin);
   }
 
   public Profile updateProfile(
@@ -41,6 +41,6 @@ public record Profile(
         phone,
         birthday,
         Optional.ofNullable(profileImage),
-        true);
+        this.isFirstLogin);
   }
 }

--- a/src/main/java/sopt/makers/authentication/domain/user/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/User.java
@@ -27,12 +27,16 @@ public class User {
   }
 
   public static User createUser(
-      final Long id, final SocialAccount socialAccount, final Profile profile) {
+      final Long id,
+      final SocialAccount socialAccount,
+      final Profile profile,
+      boolean isFirstLogin) {
     return User.builder()
         .id(id)
         .socialAccount(socialAccount)
         .profile(profile)
         .activities(new ActivityList())
+        .isFirstLogin(isFirstLogin)
         .build();
   }
 
@@ -47,6 +51,7 @@ public class User {
         .socialAccount(socialAccount)
         .profile(profile)
         .activities(activities)
+        .isFirstLogin(isFirstLogin)
         .build();
   }
 
@@ -61,7 +66,7 @@ public class User {
   }
 
   public User updateProfile(final Profile profile) {
-    return User.createUser(this.id, this.socialAccount, profile);
+    return User.createUser(this.id, this.socialAccount, profile, this.isFirstLogin);
   }
 
   public User updateIsFirstLogin() {

--- a/src/main/java/sopt/makers/authentication/domain/user/User.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/User.java
@@ -15,12 +15,14 @@ public class User {
   private final Profile profile;
   private final SocialAccount socialAccount;
   private ActivityList activities;
+  private final boolean isFirstLogin;
 
   public static User createNewUser(final SocialAccount socialAccount, final Profile profile) {
     return User.builder()
         .socialAccount(socialAccount)
         .profile(profile)
         .activities(new ActivityList())
+        .isFirstLogin(true)
         .build();
   }
 
@@ -38,7 +40,8 @@ public class User {
       final Long id,
       final SocialAccount socialAccount,
       final Profile profile,
-      final ActivityList activities) {
+      final ActivityList activities,
+      boolean isFirstLogin) {
     return User.builder()
         .id(id)
         .socialAccount(socialAccount)
@@ -53,11 +56,22 @@ public class User {
         .socialAccount(socialAccount)
         .profile(this.profile)
         .activities(this.activities)
+        .isFirstLogin(this.isFirstLogin)
         .build();
   }
 
   public User updateProfile(final Profile profile) {
-    return User.createUser(this.id, socialAccount, profile);
+    return User.createUser(this.id, this.socialAccount, profile);
+  }
+
+  public User updateIsFirstLogin() {
+    return User.builder()
+        .id(this.id)
+        .socialAccount(this.socialAccount)
+        .profile(this.profile)
+        .activities(this.activities)
+        .isFirstLogin(false)
+        .build();
   }
 
   public void joinActivity(final Activity activity) {


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #153

## Work Description ✏️
- 플레이그라운드에 인증 로직이 종속되어 있었을 때의 본래 로직
  - **구글 로그인 이후 state 필드를 통해 SIGN_UP이면 프로필 등록 뷰로 이동**
  - 사용자가 프로필 등록 뷰를 이탈하더라도 **다시 뷰를 띄우지 않음**(정기모임에서 플그 백엔드와 이야기했던 로직과의 차이점

- 인증 서버의 상황
  - 회원가입 시 로그인 계정을 연결한다고해서 바로 액세스 토큰을 반환하지 않음
  - 이에 따라 **다시 로그인을 하는 과정에서 `state` 필드로 사용자가 처음 서비스에 로그인하였는지 구분이 어려워짐**
  - 해당 문제를 해결하기 위해 `isFirstLogin` 필드를 추가하게 됨
 
- 메이커스 인증 시스템과 플레이그라운드의 관계
   - 웹/앱 모두 `isFirstLogin` 필드의 반환값을 바탕으로 유저 라우팅 경로를 변경한다
   - **case 1: 회원가입 이후 처음 로그인하는 경우** -> `isFirstLogin` 필드가 `true`로 반환되며 플레이그라운드 프로필 등록 뷰로 이동
   - **case 2: 이전에 로그인한 이력이 있는 사용자가 메인뷰에서 로그인을 하는 경우** -> `isFirstLogin` 필드가 `false`로 반환되며 로그인 이후 메인뷰로 이동
   - **case 3: 이전에 로그인한 이력이 있는 사용자가 인증이 필요하지 않은 기능을 이용하다가 인증이 필요한 기능을 클릭하여 로그인 화면으로 이동한 경우** -> `isFirstLogin` 필드가 `false`로 반환되며 로그인 이전에 접근했던 뷰로 다시 이동

- 반영 사항
  - [x] 노션 명세서 수정 완료
  - [x] 데이터베이스 컬럼 추가 및 삭제 완료 -> 기존에 옮겨둔 데이터의 is_first_login 필드의 값은 모두 false로 업데이트

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 이해안되는 부분 있으면 말씀해주세요!!