### PR TITLE
[FEAT/#181] 유저 조회시 유저 조회 시 request body로 요청하는 API 구현

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -32,6 +32,11 @@ public interface UserApi {
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
       @RequestParam List<Long> userIds);
 
+  ResponseEntity<BaseResponse<?>> getUserProfileWithBody(
+      @RequestHeader(API_KEY_HEADER) String apiKey,
+      @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
+      @RequestBody UserRequest.getUserProfileInfo userIdList);
+
   ResponseEntity<BaseResponse<?>> updateUserProfile(
       @RequestHeader(API_KEY_HEADER) String apiKey,
       @RequestHeader(SERVICE_NAME_HEADER) String serviceName,

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -30,6 +30,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -56,6 +57,19 @@ public class UserApiController implements UserApi {
     userIdValidator.validateUserIds(userIds);
     List<GetUserProfileUsecase.UserProfileAndActivityInfo> userInformation =
         getUserProfileUsecase.getUserInformation(userIds);
+
+    return ResponseUtil.success(
+        UserSuccess.GET_USER_PROFILE, UserResponse.UserProfileAndActivity.from(userInformation));
+  }
+
+  @PostMapping("")
+  public ResponseEntity<BaseResponse<?>> getUserProfileWithBody(
+      @RequestHeader(API_KEY_HEADER) String apiKey,
+      @RequestHeader(SERVICE_NAME_HEADER) String serviceName,
+      @RequestBody UserRequest.getUserProfileInfo userIdList) {
+    userIdValidator.validateUserIds(userIdList.userIds());
+    List<GetUserProfileUsecase.UserProfileAndActivityInfo> userInformation =
+        getUserProfileUsecase.getUserInformation(userIdList.userIds());
 
     return ResponseUtil.success(
         UserSuccess.GET_USER_PROFILE, UserResponse.UserProfileAndActivity.from(userInformation));

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/request/UserRequest.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/request/UserRequest.java
@@ -15,6 +15,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = PRIVATE)
 public class UserRequest {
+
+  public record getUserProfileInfo(List<Long> userIds) {}
+
   public record UserProfileInfo(
       Long userId,
       String profileImage,


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #181

## Work Description ✏️
- 다른 팀에서 유저 조회시 userId 가 많아지면 요청 파라미터가 길어지면서 414 URI too long 에러가 발생한다고 하셔서, request body로 userId를 받아서 정보 내려드리는 API를 개발했어요.
<img width="600" height="372" alt="image" src="https://github.com/user-attachments/assets/395a8839-93b4-4cc8-ba24-b801b781ba16" />

 

## PR Point 📸
기존에 db에서 유저 가져오는 로직은 이미 구현되어있어서 controller 부분만 새로 메서드 만들어주었어요!