### PR TITLE
[FIX] 유저 조회 API에 isAdmin 필터링 조건 추가

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApi.java
@@ -50,6 +50,7 @@ public interface UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
+      @RequestParam(required = false) Boolean isAdmin,
       @RequestParam(defaultValue = DEFAULT_OFFSET) @Min(0) int offset,
       @RequestParam(defaultValue = DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
       @RequestParam(defaultValue = DEFAULT_ORDER_BY) UserOrderBy orderBy);

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/user/UserApiController.java
@@ -94,12 +94,13 @@ public class UserApiController implements UserApi {
       @RequestParam(required = false) Part part,
       @RequestParam(required = false) String name,
       @RequestParam(required = false) Team team,
+      @RequestParam(required = false) Boolean isAdmin,
       @RequestParam(defaultValue = DEFAULT_OFFSET) @Min(0) int offset,
       @RequestParam(defaultValue = DEFAULT_LIMIT) @Positive @Max(MAX_LIMIT) int limit,
       @RequestParam(defaultValue = DEFAULT_ORDER_BY) UserOrderBy orderBy) {
     GetUserProfileUsecase.PaginatedUserProfiles userInformation =
         getUserProfileUsecase.getUserInformationByFilters(
-            generation, part, name, team, offset, limit, orderBy);
+            generation, part, name, team, isAdmin, offset, limit, orderBy);
 
     return ResponseUtil.success(
         UserSuccess.GET_USER_PROFILE, UserResponse.PaginatedUserProfiles.from(userInformation));

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
@@ -43,12 +43,14 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
           + "WHERE (:generation IS NULL OR a.generation = :generation) "
           + "AND (:part IS NULL OR a.part = :part) "
           + "AND (:name IS NULL OR u.name LIKE %:name%) "
-          + "AND (:team IS NULL OR a.team = :team)")
+          + "AND (:team IS NULL OR a.team = :team)"
+          + "AND (:isAdmin IS NULL OR :isAdmin = FALSE OR a.role <> 'MEMBER')")
   Page<UserEntity> findAllWithActivityHistoriesByGenerationAndPartAndNameAndTeam(
       @Param("generation") Integer generation,
       @Param("part") Part part,
       @Param("name") String name,
       @Param("team") Team team,
+      @Param("isAdmin") Boolean isAdmin,
       Pageable pageable);
 
   @Query(

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
@@ -87,9 +87,9 @@ public class UserRepositoryImpl implements UserRepository {
 
   @Override
   public Page<User> findAllByGenerationAndPartAndNameAndTeam(
-      Integer generation, Part part, String name, Team team, Pageable pageable) {
+      Integer generation, Part part, String name, Team team, Boolean isAdmin, Pageable pageable) {
     return userRetriever.findAllByGenerationAndPartAndNameAndTeam(
-        generation, part, name, team, pageable);
+        generation, part, name, team, isAdmin, pageable);
   }
 
   @Override

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
@@ -59,10 +59,10 @@ public class UserRetriever {
   }
 
   public Page<User> findAllByGenerationAndPartAndNameAndTeam(
-      Integer generation, Part part, String name, Team team, Pageable pageable) {
+      Integer generation, Part part, String name, Team team, Boolean isAdmin, Pageable pageable) {
     Page<UserEntity> userEntityPage =
         userJpaRepository.findAllWithActivityHistoriesByGenerationAndPartAndNameAndTeam(
-            generation, part, name, team, pageable);
+            generation, part, name, team, isAdmin, pageable);
 
     return userEntityPage.map(UserEntity::toDomain);
   }

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -20,6 +20,7 @@ public interface GetUserProfileUsecase {
       Part part,
       String name,
       Team team,
+      Boolean isAdmin,
       int offset,
       int limit,
       UserOrderBy orderBy);

--- a/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
@@ -34,7 +34,7 @@ public interface UserRepository {
   boolean existsByPhone(String phone);
 
   Page<User> findAllByGenerationAndPartAndNameAndTeam(
-      Integer generation, Part part, String name, Team team, Pageable pageable);
+      Integer generation, Part part, String name, Team team, Boolean isAdmin, Pageable pageable);
 
   int countByGeneration(int generation);
 }

--- a/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
@@ -61,6 +61,7 @@ public class GetUserProfileService implements GetUserProfileUsecase {
       Part part,
       String name,
       Team team,
+      Boolean isAdmin,
       int offset,
       int limit,
       UserOrderBy orderBy) {
@@ -68,7 +69,7 @@ public class GetUserProfileService implements GetUserProfileUsecase {
 
     Page<User> userEntityPage =
         userRepository.findAllByGenerationAndPartAndNameAndTeam(
-            generation, part, name, team, pageable);
+            generation, part, name, team, isAdmin, pageable);
 
     long totalCount = userEntityPage.getTotalElements();
     boolean hasNext = userEntityPage.hasNext();


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #178

## Work Description ✏️
- 플그 임원진 필터링을 위해 유저 조회 API에 isAdmin parameter를 추가했어요.
<img width="200" height="343" alt="image" src="https://github.com/user-attachments/assets/52ae8d6c-a29d-4998-97b5-61a48058cbb2" />

- 동작은 다음과 같습니다
  1) isAdmin 필드 없이 요청했을 경우 -> 필터링 조건으로 사용하지 않아요
  2) isAdmin 필드가 false일 경우 -> 필터링 조건으로 사용하지 않아요 
  (MEMBER만 필터링 하는 기능은 없기 때문에 모든 회원을 반환해요)
  3) isAdmin 필드가 true일 경우 -> role이 MEMBER가 아닌 모든 회원을 반환해요 
  (MEMBER가 아닌 모든 role은 임원진이기 때문이에용)

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
