### PR TITLE
[INFRA/#194] 도커 이미지 보관 개수를 dev(2개), prod(5개)로 제한

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -21,7 +21,7 @@ jobs:
           cache: gradle
 
       - name: 🔒 Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
@@ -50,15 +50,49 @@ jobs:
         run: ./gradlew build --no-daemon
         shell: bash
 
-      - name: 🧱 Build Image and Push to ECR
+      - name: 🧱 Build Image and Push to ECR Public
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_ECR_REPO: ${{ secrets.AWS_ECR_REPO_DEV }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
+          IMAGE_SHA_TAG=$(echo $GITHUB_SHA | cut -c1-8)
+
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-          docker build --build-arg PROFILE=dev -t $AWS_ECR_REPO .
-          docker tag $AWS_ECR_REPO:latest public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:latest
+          
+          docker build --build-arg PROFILE=dev \
+            -t public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:latest \
+            -t public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:$IMAGE_SHA_TAG .
+
           docker push public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:latest
+          docker push public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:$IMAGE_SHA_TAG
+
+      - name: 🗑️ Prune old ECR Public images (keep 2 latest)
+        env:
+          ECR_APP_NAME: ${{ secrets.AWS_ECR_REPO_DEV }}
+        run: |
+          echo "Pruning old images, keeping only 2 most recent..."
+          IMAGES=$(aws ecr-public describe-images \
+            --region us-east-1 \
+            --repository-name $ECR_APP_NAME \
+            --query 'sort_by(imageDetails,& imagePushedAt)[*].imageDigest' \
+            --output json)
+
+          COUNT=$(echo $IMAGES | jq length)
+
+          if [ "$COUNT" -gt 2 ]; then
+            TO_DELETE=$(echo $IMAGES | jq -c ".[:$((COUNT-2))] | [{imageDigest: .[]}]")
+            if [ "$TO_DELETE" != "[]" ]; then
+              aws ecr-public batch-delete-image \
+                --region us-east-1 \
+                --repository-name $ECR_APP_NAME \
+                --image-ids "$TO_DELETE"
+            else
+              echo "No images to delete."
+            fi
+          else
+            echo "Less than or equal to 2 images, skipping prune."
+          fi
 
   deploy:
     needs: build-and-push-image
@@ -68,7 +102,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🔒 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -6,7 +6,6 @@ on:
     branches: [ prod ]
 
 jobs:
-
   build-and-push-image:
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +20,7 @@ jobs:
           cache: gradle
 
       - name: 🔒 Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
@@ -50,62 +49,48 @@ jobs:
         run: ./gradlew build --no-daemon
         shell: bash
 
-      - name: 🧱 Build Image and Push to ECR
+      - name: 🧱 Build Image and Push to ECR Public
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_ECR_REPO: ${{ secrets.AWS_ECR_REPO_PROD }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
+          IMAGE_SHA_TAG=$(echo $GITHUB_SHA | cut -c1-8)
+
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-          docker build --build-arg PROFILE=prod -t $AWS_ECR_REPO .
-          docker tag $AWS_ECR_REPO:latest public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:latest
+          
+          # build & tag directly with full repo path
+          docker build --build-arg PROFILE=prod \
+            -t public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:latest \
+            -t public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:$IMAGE_SHA_TAG .
+
+          # push both tags
           docker push public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:latest
+          docker push public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:$IMAGE_SHA_TAG
 
-  deploy:
-    needs: build-and-push-image
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout Source
-        uses: actions/checkout@v3
-
-      - name: 🔒 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: 📂 Download Keys and Env from S3
+      - name: 🗑️ Prune old ECR Public images (keep 5 latest)
         env:
-          REGION: ${{ secrets.AWS_REGION }}
-          S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          JWT_PUBLIC_KEY_PATH: ${{ secrets.JWT_PUBLIC_KEY_PATH }}
-          JWT_PRIVATE_KEY_PATH: ${{ secrets.JWT_PRIVATE_KEY_PATH }}
-          PROD_ENV_FILE_PATH: ${{ secrets.ENV_FILE_PATH_PROD }}
+          ECR_APP_NAME: ${{ secrets.AWS_ECR_REPO_PROD }}
         run: |
-          mkdir -p ./key
-          aws s3 cp s3://$S3_BUCKET/prod/static/$JWT_PUBLIC_KEY_PATH ./key/jwt_public_key.pem --region $REGION
-          aws s3 cp s3://$S3_BUCKET/prod/static/$JWT_PRIVATE_KEY_PATH ./key/jwt_private_key.pem --region $REGION
-          aws s3 cp s3://$S3_BUCKET/prod/$PROD_ENV_FILE_PATH .env --region $REGION
+          echo "Pruning old images, keeping only 5 most recent..."
+          IMAGES=$(aws ecr-public describe-images \
+            --region us-east-1 \
+            --repository-name $ECR_APP_NAME \
+            --query 'sort_by(imageDetails,& imagePushedAt)[*].imageDigest' \
+            --output json)
 
-      - name: 🔄 Transfer Deployment Files to EC2
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.HOST_PROD }}
-          username: ubuntu
-          key: ${{ secrets.PEM_KEY_PROD }}
-          port: 22
-          source: ".env,docker-compose.yml,scripts,key"
-          target: /home/ubuntu/authentication
-          overwrite: true
+          COUNT=$(echo $IMAGES | jq length)
 
-      - name: 🚀 Remote SSH Deployment
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.HOST_PROD }}
-          username: ubuntu
-          key: ${{ secrets.PEM_KEY_PROD }}
-          port: 22
-          script: |
-            sudo chmod +x /home/ubuntu/authentication/scripts/*.sh
-            cd /home/ubuntu/authentication/scripts
-            ./deploy.sh
+          if [ "$COUNT" -gt 5 ]; then
+            TO_DELETE=$(echo $IMAGES | jq -c ".[:$((COUNT-5))] | [{imageDigest: .[]}]")
+            if [ "$TO_DELETE" != "[]" ]; then
+              aws ecr-public batch-delete-image \
+                --region us-east-1 \
+                --repository-name $ECR_APP_NAME \
+                --image-ids "$TO_DELETE"
+            else
+              echo "No images to delete."
+            fi
+          else
+            echo "Less than or equal to 5 images, skipping prune."
+          fi


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #194

## Work Description ✏️
- dev 환경에서는 이미지를 최대 2개, prod 환경에서는 최대 5개 registry에 보관하도록 cd 워크플로우를 변경해주었습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
