### PR TITLE
[Feat/#210] /refresh/web - RefreshCookie 없을 경우 예외처리 + CookieUtil domain 지정

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/controller/auth/AuthApiController.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/controller/auth/AuthApiController.java
@@ -12,6 +12,7 @@ import sopt.makers.authentication.application.port.in.auth.AuthenticateSocialAcc
 import sopt.makers.authentication.application.port.in.auth.CreatePhoneVerificationUsecase;
 import sopt.makers.authentication.application.port.in.auth.SignUpUsecase;
 import sopt.makers.authentication.application.port.in.auth.VerifyPhoneVerificationUsecase;
+import sopt.makers.authentication.domain.auth.exception.AuthFailure;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -91,10 +92,13 @@ public class AuthApiController implements AuthApi {
   @PostMapping("/refresh/web")
   public ResponseEntity<BaseResponse<?>> refreshTokenFromWeb(
       @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
-      @CookieValue(REFRESH_TOKEN_HEADER) String refreshToken) {
+      @CookieValue(value = REFRESH_TOKEN_HEADER, required = false) String refreshToken) {
+    if (refreshToken == null) {
+      return ResponseUtil.failure(AuthFailure.REFRESH_TOKEN_NOT_FOUND);
+    }
+
     AuthRequest.AuthenticationTokenInfo authenticationTokenInfo =
         new AuthRequest.AuthenticationTokenInfo(accessToken, refreshToken);
-
     AuthenticateSocialAccountUsecase.AuthenticateTokenInfo tokenInfo =
         authenticateSocialAccountUsecase.refresh(authenticationTokenInfo.toCommand());
     HttpHeaders headers = cookieUtil.setRefreshToken(tokenInfo.refreshToken());

--- a/src/main/java/sopt/makers/authentication/adapter/in/web/util/CookieUtil.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/util/CookieUtil.java
@@ -1,6 +1,8 @@
 package sopt.makers.authentication.adapter.in.web.util;
 
 import static sopt.makers.authentication.adapter.out.jwt.JwtConstant.REFRESH_TOKEN_HEADER;
+import static sopt.makers.authentication.common.constant.CookieConstant.COOKIE_DOMAIN;
+import static sopt.makers.authentication.common.constant.CookieConstant.SAME_SITE_NONE;
 import static sopt.makers.authentication.common.constant.SystemConstant.PATTERN_ROOT_PATH;
 
 import sopt.makers.authentication.config.SecurityProperty;
@@ -17,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CookieUtil {
   private final SecurityProperty securityProperty;
-  private static final String SAME_SITE_NONE = "None";
 
   public HttpHeaders setRefreshToken(String refreshToken) {
     long durationMillis = securityProperty.jwt().secret().expiration().refreshTokenExpiration();
@@ -27,6 +28,7 @@ public class CookieUtil {
             .httpOnly(true)
             .secure(true)
             .sameSite(SAME_SITE_NONE)
+            .domain(COOKIE_DOMAIN)
             .path(PATTERN_ROOT_PATH)
             .maxAge(duration)
             .build();

--- a/src/main/java/sopt/makers/authentication/common/constant/CookieConstant.java
+++ b/src/main/java/sopt/makers/authentication/common/constant/CookieConstant.java
@@ -1,0 +1,9 @@
+package sopt.makers.authentication.common.constant;
+
+public final class CookieConstant {
+  private CookieConstant() {}
+
+  public static final String SAME_SITE_NONE = "None";
+  public static final String COOKIE_DOMAIN = ".sopt.org";
+  public static final String CORS_ALLOWED_ORIGIN_PATTERN = "https://*.sopt.org";
+}

--- a/src/main/java/sopt/makers/authentication/config/WebConfig.java
+++ b/src/main/java/sopt/makers/authentication/config/WebConfig.java
@@ -1,0 +1,23 @@
+package sopt.makers.authentication.config;
+
+import static sopt.makers.authentication.common.constant.CookieConstant.CORS_ALLOWED_ORIGIN_PATTERN;
+import static sopt.makers.authentication.common.constant.SystemConstant.PATTERN_ALL;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry
+        .addMapping(PATTERN_ALL)
+        .allowedOriginPatterns(CORS_ALLOWED_ORIGIN_PATTERN)
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+        .allowedHeaders("Authorization", "Content-Type")
+        .allowCredentials(true)
+        .maxAge(3600);
+  }
+}

--- a/src/main/java/sopt/makers/authentication/config/WebConfig.java
+++ b/src/main/java/sopt/makers/authentication/config/WebConfig.java
@@ -1,7 +1,9 @@
 package sopt.makers.authentication.config;
 
 import static sopt.makers.authentication.common.constant.CookieConstant.CORS_ALLOWED_ORIGIN_PATTERN;
+import static sopt.makers.authentication.common.constant.SystemConstant.API_KEY_HEADER;
 import static sopt.makers.authentication.common.constant.SystemConstant.PATTERN_ALL;
+import static sopt.makers.authentication.common.constant.SystemConstant.SERVICE_NAME_HEADER;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -16,7 +18,7 @@ public class WebConfig implements WebMvcConfigurer {
         .addMapping(PATTERN_ALL)
         .allowedOriginPatterns(CORS_ALLOWED_ORIGIN_PATTERN)
         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
-        .allowedHeaders("Authorization", "Content-Type")
+        .allowedHeaders("Authorization", "Content-Type", API_KEY_HEADER, SERVICE_NAME_HEADER)
         .allowCredentials(true)
         .maxAge(3600);
   }

--- a/src/main/java/sopt/makers/authentication/domain/auth/exception/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/exception/AuthFailure.java
@@ -22,6 +22,7 @@ public enum AuthFailure implements FailureCode {
   // 401
   INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "API 키가 유효하지 않습니다."),
   MISSING_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 없습니다."),
+  REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Refresh Token이 없습니다."),
 
   // 403
   PHONE_NOT_VERIFIED(HttpStatus.FORBIDDEN, "번호 인증이 되지 않은 번호입니다."),


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #210 

## Work Description ✏️
- 스프링부트 내 WebConfig로 allowOrigins 명시
- CookieUtil에서 Cookie 생성 시 도메인 지정
- 명시적으로 refresh token이 null이면 401 예외처리 추가

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
