### PR TITLE
[Fix/#214] WebConfig allowOrigins 범위 수정

### DIFF
--- a/src/main/java/sopt/makers/authentication/common/constant/CookieConstant.java
+++ b/src/main/java/sopt/makers/authentication/common/constant/CookieConstant.java
@@ -5,5 +5,7 @@ public final class CookieConstant {
 
   public static final String SAME_SITE_NONE = "None";
   public static final String COOKIE_DOMAIN = ".sopt.org";
-  public static final String CORS_ALLOWED_ORIGIN_PATTERN = "https://*.sopt.org";
+  public static final String[] CORS_ALLOWED_ORIGINS = {
+    "https://sopt-internal-dev.sopt.org", "https://playground.sopt.org"
+  };
 }

--- a/src/main/java/sopt/makers/authentication/config/WebConfig.java
+++ b/src/main/java/sopt/makers/authentication/config/WebConfig.java
@@ -1,6 +1,6 @@
 package sopt.makers.authentication.config;
 
-import static sopt.makers.authentication.common.constant.CookieConstant.CORS_ALLOWED_ORIGIN_PATTERN;
+import static sopt.makers.authentication.common.constant.CookieConstant.CORS_ALLOWED_ORIGINS;
 import static sopt.makers.authentication.common.constant.SystemConstant.API_KEY_HEADER;
 import static sopt.makers.authentication.common.constant.SystemConstant.PATTERN_ALL;
 import static sopt.makers.authentication.common.constant.SystemConstant.SERVICE_NAME_HEADER;
@@ -16,7 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
   public void addCorsMappings(CorsRegistry registry) {
     registry
         .addMapping(PATTERN_ALL)
-        .allowedOriginPatterns(CORS_ALLOWED_ORIGIN_PATTERN)
+        .allowedOrigins(CORS_ALLOWED_ORIGINS)
         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
         .allowedHeaders("Authorization", "Content-Type", API_KEY_HEADER, SERVICE_NAME_HEADER)
         .allowCredentials(true)


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #214 

## Work Description ✏️
- `Access-Control-Allow-Origin`에 `*(wildcard)` 또는 패턴이 들어가 있을 때, `Access-Control-Allow-Credentials: true`를 설정하면 보안상 쿠키를 보내면 안 된다라는 정책에 따라 플레이그라운드 도메인을 직접 명시하도록 수정

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
