### PR TITLE
[REFACTOR/#226] 불필요한 라이브러리 제거(mysql, fixturemonkey...)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,13 +32,10 @@ configurations {
 	}
 }
 
-val archunitVersion = "${property("archunitVersion")}"
-val fixtureMonkeyVersion = "${property("fixturemonkeyVersion")}"
 val jacksonCoreVersion = "${property("jacksonDataBindVersion")}"
 val okHttpVersion = "${property("okHttp3Version")}"
 val gsonVersion = "${property("gsonVersion")}"
 val bouncycastleVersion = "${property("bouncycastleVersion")}"
-val jsonwebtokenVersion = "${property("jsonwebtokenVersion")}"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
@@ -60,21 +57,15 @@ dependencies {
 	implementation("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
 
 	compileOnly("org.projectlombok:lombok")
-	runtimeOnly("org.postgresql:postgresql")
-	runtimeOnly("com.mysql:mysql-connector-j")
 	annotationProcessor("org.projectlombok:lombok")
 
-	implementation("io.jsonwebtoken:jjwt-api:${jsonwebtokenVersion}")
-	runtimeOnly("io.jsonwebtoken:jjwt-impl:${jsonwebtokenVersion}")
-	runtimeOnly("io.jsonwebtoken:jjwt-jackson:${jsonwebtokenVersion}")
+    runtimeOnly("org.postgresql:postgresql")
 
 	implementation("org.springframework.boot:spring-boot-starter-cache")
 	implementation("com.github.ben-manes.caffeine:caffeine")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
-	testImplementation("com.tngtech.archunit:archunit:${archunitVersion}")
-	testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:${fixtureMonkeyVersion}")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testRuntimeOnly("com.h2database:h2")
 }


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #226 

## Work Description ✏️
- dev 환경 람다 배포를 통해 비용 절감을 하기 위해서는 jar 파일의 크기가 압축 전 -> 후 각각 250MB, 50MB 이하여야 합니다
- 현재 인증 서버 같은 경우 불필요한 라이브러리로 인해 압축 전 69MB, 압축 후 61MB인 상황이었고, 파일 용량을 줄여보고자 현재 사용하지 않고 있는 불필요한 라이브러리 제거하였습니다.
- 제거 결과: 압축 전 66MB, 압축 후 59MB
- 압축 전 용량이 250MB 이하이기 때문에 라이브러리만 lambda layer로 분리하는 방법에 대해서 조금 더 알아볼 예정이에요

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
