### PR TITLE
[FEAT#236] 기존 유저 정보 조회시 메이커스 기수 활동 정보 추가 

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
+++ b/src/main/java/sopt/makers/authentication/adapter/in/web/dto/user/response/UserResponse.java
@@ -45,14 +45,15 @@ public final class UserResponse {
   }
 
   public record UserActivityDetail(
-      long activityId, int generation, String part, String team, String role) {
+      long activityId, int generation, String part, String team, String role, boolean isSopt) {
     public static UserActivityDetail from(GetUserProfileUsecase.UserActivityInfo userActivityInfo) {
       return new UserActivityDetail(
           userActivityInfo.activityId(),
           userActivityInfo.generation(),
           userActivityInfo.part(),
           userActivityInfo.team(),
-          userActivityInfo.role());
+          userActivityInfo.role(),
+          userActivityInfo.isSopt());
     }
   }
 

--- a/src/main/java/sopt/makers/authentication/adapter/out/cache/dto/CachedUserActivity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/cache/dto/CachedUserActivity.java
@@ -1,4 +1,4 @@
 package sopt.makers.authentication.adapter.out.cache.dto;
 
 public record CachedUserActivity(
-    long activityId, int generation, String part, String team, String role) {}
+    long activityId, int generation, String part, String team, String role, boolean isSopt) {}

--- a/src/main/java/sopt/makers/authentication/adapter/out/cache/mapper/UserMapper.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/cache/mapper/UserMapper.java
@@ -36,7 +36,8 @@ public class UserMapper {
         activity.getGeneration(),
         activity.getPart().getName(),
         activity.getTeam() != null ? activity.getTeam().getName() : null,
-        activity.getRole().name());
+        activity.getRole().name(),
+        activity.isSopt());
   }
 
   public User toDomain(CachedUserProfile cached) {
@@ -58,6 +59,7 @@ public class UserMapper {
     Part part = Part.findPart(cached.part());
     Team team = cached.team() != null ? Team.findTeam(cached.team()) : null;
     Role role = Role.valueOf(cached.role());
-    return Activity.of(cached.activityId(), cached.generation(), team, part, role);
+    boolean isSopt = cached.isSopt();
+    return Activity.of(cached.activityId(), cached.generation(), team, part, role, isSopt);
   }
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserActivityHistoryEntity.java
@@ -8,6 +8,7 @@ import sopt.makers.authentication.domain.user.Role;
 import sopt.makers.authentication.domain.user.Team;
 import sopt.makers.authentication.domain.user.User;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -32,7 +33,7 @@ import lombok.Setter;
     uniqueConstraints = {
       @UniqueConstraint(
           name = "UK_USER_ID_AND_GENERATION",
-          columnNames = {"user_id", "generation"})
+          columnNames = {"user_id", "generation", "isSopt"})
     })
 public class UserActivityHistoryEntity {
   @Id
@@ -59,17 +60,23 @@ public class UserActivityHistoryEntity {
   @Enumerated(EnumType.STRING)
   private Role role;
 
+  @NotNull
+  @Column(name = "is_sopt")
+  private boolean isSopt;
+
   private UserActivityHistoryEntity(
       final UserEntity user,
       final int generation,
       final Team team,
       final Part part,
-      final Role role) {
+      final Role role,
+      final boolean isSopt) {
     this.user = user;
     this.generation = generation;
     this.team = team;
     this.part = part;
     this.role = role;
+    this.isSopt = isSopt;
   }
 
   public static UserActivityHistoryEntity fromDomain(final User user, final Activity activity) {
@@ -80,7 +87,8 @@ public class UserActivityHistoryEntity {
             activity.getGeneration(),
             activity.optionalTeam().orElse(null),
             activity.getPart(),
-            activity.getRole());
+            activity.getRole(),
+            activity.isSopt());
 
     if (activity.getId() != null) {
       userActivityHistoryEntity.setId(activity.getId());
@@ -89,6 +97,6 @@ public class UserActivityHistoryEntity {
   }
 
   public Activity toDomain() {
-    return Activity.of(id, generation, team, part, role);
+    return Activity.of(id, generation, team, part, role, isSopt);
   }
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserActivityHistoryEntity.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserActivityHistoryEntity.java
@@ -33,7 +33,7 @@ import lombok.Setter;
     uniqueConstraints = {
       @UniqueConstraint(
           name = "UK_USER_ID_AND_GENERATION",
-          columnNames = {"user_id", "generation", "isSopt"})
+          columnNames = {"user_id", "generation", "is_sopt"})
     })
 public class UserActivityHistoryEntity {
   @Id

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
@@ -58,8 +58,9 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
           + "FROM UserEntity u "
           + "JOIN u.userActivityHistoryList a "
           + "WHERE a.generation = :generation "
-          + "AND a.isSopt = true")
-  int countByGenerationAndIsSopt(@Param("generation") int generation);
+          + "AND a.isSopt = :isSopt")
+  int countByGenerationAndIsSopt(
+      @Param("generation") int generation, @Param("isSopt") boolean isSopt);
 
   void deleteById(Long userId);
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
@@ -57,8 +57,9 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
       "SELECT COUNT(DISTINCT u.id) "
           + "FROM UserEntity u "
           + "JOIN u.userActivityHistoryList a "
-          + "WHERE a.generation = :generation")
-  int countByGeneration(@Param("generation") int generation);
+          + "WHERE a.generation = :generation "
+          + "AND a.isSopt = true")
+  int countByGenerationAndIsSopt(@Param("generation") int generation);
 
   void deleteById(Long userId);
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
@@ -93,7 +93,7 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
-  public int countByGeneration(int generation) {
+  public int countByGenerationAndIsSopt(int generation) {
     return userRetriever.countByGeneration(generation);
   }
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRepositoryImpl.java
@@ -93,7 +93,7 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
-  public int countByGenerationAndIsSopt(int generation) {
-    return userRetriever.countByGeneration(generation);
+  public int countByGenerationAndIsSopt(int generation, boolean isSopt) {
+    return userRetriever.countByGenerationAndIsSopt(generation, isSopt);
   }
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
@@ -67,7 +67,7 @@ public class UserRetriever {
     return userEntityPage.map(UserEntity::toDomain);
   }
 
-  public int countByGeneration(int generation) {
-    return userJpaRepository.countByGenerationAndIsSopt(generation);
+  public int countByGenerationAndIsSopt(int generation, boolean isSopt) {
+    return userJpaRepository.countByGenerationAndIsSopt(generation, isSopt);
   }
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
@@ -68,6 +68,6 @@ public class UserRetriever {
   }
 
   public int countByGeneration(int generation) {
-    return userJpaRepository.countByGeneration(generation);
+    return userJpaRepository.countByGenerationAndIsSopt(generation);
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -54,14 +54,16 @@ public interface GetUserProfileUsecase {
     }
   }
 
-  record UserActivityInfo(long activityId, int generation, String part, String team, String role) {
+  record UserActivityInfo(
+      long activityId, int generation, String part, String team, String role, boolean isSopt) {
     public static UserActivityInfo of(Activity activity) {
       return new UserActivityInfo(
           activity.getId(),
           activity.getGeneration(),
           activity.getPart().getName(),
           activity.getTeam() != null ? activity.getTeam().getName() : null,
-          activity.getRole().name());
+          activity.getRole().name(),
+          activity.isSopt());
     }
   }
 

--- a/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
+++ b/src/main/java/sopt/makers/authentication/application/port/in/user/GetUserProfileUsecase.java
@@ -49,7 +49,7 @@ public interface GetUserProfileUsecase {
           profile.birthday(),
           profile.phone(),
           profile.email().orElse(null),
-          activities.getLastActivity().getGeneration(),
+          activities.getLastSoptActivity().getGeneration(),
           userActivityInfos);
     }
   }

--- a/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
@@ -36,5 +36,5 @@ public interface UserRepository {
   Page<User> findAllByGenerationAndPartAndNameAndTeam(
       Integer generation, Part part, String name, Team team, Boolean isAdmin, Pageable pageable);
 
-  int countByGenerationAndIsSopt(int generation);
+  int countByGenerationAndIsSopt(int generation, boolean isSopt);
 }

--- a/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
+++ b/src/main/java/sopt/makers/authentication/application/port/out/user/UserRepository.java
@@ -36,5 +36,5 @@ public interface UserRepository {
   Page<User> findAllByGenerationAndPartAndNameAndTeam(
       Integer generation, Part part, String name, Team team, Boolean isAdmin, Pageable pageable);
 
-  int countByGeneration(int generation);
+  int countByGenerationAndIsSopt(int generation);
 }

--- a/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
@@ -49,47 +49,10 @@ public class SignUpService implements SignUpUsecase {
   @Transactional
   @Override
   public void signUp(SignUpCommand command) {
-    // for concurrency test
-    //    if (command.phone().matches("^0100000\\d{4}$")) {
-    //      signUpConcurrency(command.token(), command.authPlatform(), command.phone());
-    //      return ;
-    //    }
-
     if (isMagicPhone(command.phone())) {
       signUpForMagicNumber(command.token(), command.authPlatform());
     } else {
       signUpForSoptUser(command.token(), command.phone(), command.authPlatform());
-    }
-  }
-
-  private void signUpConcurrency(String token, AuthPlatform authPlatform, String phone) {
-    UserRegisterInfo targetRegisterInfo =
-        userRegisterInfoRepository
-            .findByPhone(phone)
-            .orElseThrow(() -> new AuthException(NOT_FOUND_REGISTER_INFO));
-    SocialAccount socialAccount = createSocialAccount(phone, authPlatform);
-    Profile profile = createProfile(targetRegisterInfo);
-    Activity activity = createActivity(targetRegisterInfo);
-    User newUser = User.createNewUser(socialAccount, profile);
-    User savedUser = userRepository.save(newUser);
-
-    try {
-      userActivityHistoryRepository.save(savedUser, activity);
-      userRegisterInfoRepository.delete(targetRegisterInfo);
-      appClient.createMemberProfile(savedUser.getId());
-      playgroundClient.createMemberProfile(savedUser.getId());
-    } catch (AppRequestException | AppResponseException e) {
-      // 케이스 1: App이 실패 → Playground는 요청 시도 x
-      log.error("앱 유저 생성 요청 실패 userId={}", savedUser.getId());
-      throw new AuthException(APP_SYNC_FAIL);
-    } catch (PlaygroundRequestException | PlaygroundResponseException e) {
-      // 케이스 2: App은 성공했지만 Playground 실패
-      try {
-        appClient.deleteMemberProfile(savedUser.getId());
-      } catch (Exception ex) {
-        log.error("앱 유저 Delete 요청 실패 userId={}", savedUser.getId());
-      }
-      throw new AuthException(PLAYGROUND_SYNC_FAIL);
     }
   }
 
@@ -151,7 +114,7 @@ public class SignUpService implements SignUpUsecase {
   }
 
   private Activity createActivity(UserRegisterInfo registerInfo) {
-    return Activity.of(registerInfo.getGeneration(), null, registerInfo.getPart());
+    return Activity.of(registerInfo.getGeneration(), null, registerInfo.getPart(), true);
   }
 
   private boolean isMagicPhone(String phone) {

--- a/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
@@ -114,6 +114,9 @@ public class SignUpService implements SignUpUsecase {
   }
 
   private Activity createActivity(UserRegisterInfo registerInfo) {
+    /*
+    SOPT 앱을 최초 회원가입하는 경우 => isSopt는 무조건 true로 설정, 메이커스 활동 회원들은 매 기수 시작시 => isSopt false인 기수 레코드 추가하는 작업 필요
+     */
     return Activity.of(registerInfo.getGeneration(), null, registerInfo.getPart(), true);
   }
 

--- a/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
@@ -96,7 +96,7 @@ public class GetUserProfileService implements GetUserProfileUsecase {
 
   @Override
   public UserCountByGeneration getUserCountByGeneration(int generation) {
-    int count = userRepository.countByGeneration(generation);
+    int count = userRepository.countByGenerationAndIsSopt(generation);
     return new UserCountByGeneration(count);
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/GetUserProfileService.java
@@ -96,7 +96,7 @@ public class GetUserProfileService implements GetUserProfileUsecase {
 
   @Override
   public UserCountByGeneration getUserCountByGeneration(int generation) {
-    int count = userRepository.countByGenerationAndIsSopt(generation);
+    int count = userRepository.countByGenerationAndIsSopt(generation, true);
     return new UserCountByGeneration(count);
   }
 }

--- a/src/main/java/sopt/makers/authentication/application/service/user/UpdateUserProfileService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/user/UpdateUserProfileService.java
@@ -99,7 +99,8 @@ public class UpdateUserProfileService implements UpdateUserProfileUsecase {
                   existing.getGeneration(),
                   c.team() == null ? null : Team.findTeam(c.team()),
                   existing.getPart(),
-                  existing.getRole());
+                  existing.getRole(),
+                  existing.isSopt());
             })
         .toList();
   }

--- a/src/main/java/sopt/makers/authentication/domain/user/Activity.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Activity.java
@@ -15,22 +15,30 @@ public class Activity {
   private final Team team;
   private final Part part;
   private final Role role;
+  private final boolean isSopt;
 
-  private Activity(Long id, int generation, Team team, Part part, Role role) {
+  private Activity(Long id, int generation, Team team, Part part, Role role, boolean isSopt) {
     this.id = id;
     this.generation = generation;
     this.team = team;
     this.part = part;
     this.role = role;
-  }
-
-  public static Activity of(int generation, final Team team, final Part part) {
-    return new Activity(null, generation, team, part, Role.MEMBER);
+    this.isSopt = isSopt;
   }
 
   public static Activity of(
-      Long id, int generation, final Team team, final Part part, final Role role) {
-    return new Activity(id, generation, team, part, role);
+      int generation, final Team team, final Part part, final boolean isSopt) {
+    return new Activity(null, generation, team, part, Role.MEMBER, isSopt);
+  }
+
+  public static Activity of(
+      Long id,
+      int generation,
+      final Team team,
+      final Part part,
+      final Role role,
+      final boolean isSopt) {
+    return new Activity(id, generation, team, part, role, isSopt);
   }
 
   public Optional<Team> optionalTeam() {

--- a/src/main/java/sopt/makers/authentication/domain/user/ActivityList.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/ActivityList.java
@@ -1,6 +1,7 @@
 package sopt.makers.authentication.domain.user;
 
 import static sopt.makers.authentication.domain.user.exception.UserFailure.DUPLICATE_ACTIVITY;
+import static sopt.makers.authentication.domain.user.exception.UserFailure.NOT_FOUND_USER_ACTIVITY;
 
 import sopt.makers.authentication.domain.user.exception.UserException;
 
@@ -42,6 +43,13 @@ public class ActivityList {
 
   public Activity getLastActivity() {
     return activities.getLast();
+  }
+
+  public Activity getLastSoptActivity() {
+    return activities.stream()
+        .filter(Activity::isSopt)
+        .reduce((first, second) -> second)
+        .orElseThrow(() -> new UserException(NOT_FOUND_USER_ACTIVITY));
   }
 
   public int getTotalActivitySize() {

--- a/src/main/java/sopt/makers/authentication/domain/user/Part.java
+++ b/src/main/java/sopt/makers/authentication/domain/user/Part.java
@@ -17,7 +17,14 @@ public enum Part {
   SERVER("서버"),
   DESIGN("디자인"),
   PLAN("기획"),
-  WEB("웹");
+  WEB("웹"),
+
+  // SOPT MAKERS 챕터
+  PM("PM"),
+  FRONTEND("프론트엔드"),
+  BACKEND("백엔드"),
+  MARKETING("마케팅"),
+  CX("CX");
 
   private final String name;
 


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #236 

## Work Description ✏️

### 메이커스 배지 표시를 위한 인증 서버 작업을 했습니다!
변경사항들은 아래와 같아요!

1) 유저 정보 조회 (GET/POST - 유저 정보 조회 - GET) API의 Response Body에 isSopt 필드 추가
```java
{
	"lastGeneration": 37
	"activities"[
	  {
	    "generation": 37,
	    "isSopt": true,
	    "part": "백엔드",
	    "team": "메이커스",
	    "role": "팀장"
	  }
 ]
}
```
<br/>

2) 기수별 유저 수 조회 API 로직 수정
어드민에서 쓰는 API인데, isSopt가 true인 회원만 거르도록 했습니다! (기존이 sopt 회원만 넘기는 로직이었어요)


3) user_activity_histories 엔티티 유니크 제약 조건 수정 및 isSopt 컬럼 추가
- 기존에 (user_id, generation)으로 걸려있었는데, 메이커스 기수도 솝트기수를 따라가기 때문에 메이커스와 솝트를 병행하는 경우가 문제가 되어 isSopt도 포함하여 유니크 제약조건을 걸도록 했습니다!
https://github.com/sopt-makers/sopt-auth-backend/blob/ba4138e571f4895c068131d113251b167310d8a4/src/main/java/sopt/makers/authentication/adapter/out/persistence/entity/UserActivityHistoryEntity.java#L31-L38
<br/>

4) part enum 추가
https://github.com/sopt-makers/sopt-auth-backend/blob/ba4138e571f4895c068131d113251b167310d8a4/src/main/java/sopt/makers/authentication/domain/user/Part.java#L22-L27
<br/>

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->

### 전달사항
1. local.env 노션에 `USER_PATH=/api/v1/users`가 누락되어있더라구요, 추가해두었습니다!!
2. 인수인계할 때 makers 매 기수마다 활동 정보 넣어줘야 한다는 것도 같이 인수인계할 때 말씀드려야 할 것 같아요~!



`TO-DO`
- (dev/prod db) user_activity_histories 유니크 제약조건 수정하기 (datagrip)
- (dev/prod db) 솝트 활동기수는 isSopt true로 메이커스 기수는 isSopt false로 설정
- (dev/prod db) 메이커스 회원들의 활동 정보 user_activity_histories에 채워넣기
- csv 파일 받고, 챕터명 수정되는 부분있으면 enum 수정하기

