### PR TITLE
[FEAT/#256] 회원가입 시 이미 회원가입을 한 이력이 있는 소셜 계정 연결 시 400 오류 반환하는 로직 구현

### DIFF
--- a/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
@@ -1,5 +1,6 @@
 package sopt.makers.authentication.application.service.auth;
 
+import static sopt.makers.authentication.domain.auth.exception.AuthFailure.ALREADY_REGISTERED_SOCIAL_ACCOUNT;
 import static sopt.makers.authentication.domain.auth.exception.AuthFailure.APP_SYNC_FAIL;
 import static sopt.makers.authentication.domain.auth.exception.AuthFailure.INVALID_SOCIAL_PLATFORM;
 import static sopt.makers.authentication.domain.auth.exception.AuthFailure.NOT_FOUND_REGISTER_INFO;
@@ -27,6 +28,7 @@ import sopt.makers.authentication.domain.user.Profile;
 import sopt.makers.authentication.domain.user.User;
 import sopt.makers.authentication.domain.user.UserRegisterInfo;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -82,12 +84,17 @@ public class SignUpService implements SignUpUsecase {
       userRegisterInfoRepository.delete(targetRegisterInfo);
       appClient.createMemberProfile(savedUser.getId());
       playgroundClient.createMemberProfile(savedUser.getId());
+    } catch (DataIntegrityViolationException e) {
+      // 케이스 1: Unique Key 제약 조건 위반 (이미 가입된 소셜 계정)
+      log.error(
+          "중복된 소셜 계정으로 회원가입 시도 authPlatform={}, authPlatformId={}", authPlatform, authPlatformId);
+      throw new AuthException(ALREADY_REGISTERED_SOCIAL_ACCOUNT);
     } catch (AppRequestException | AppResponseException e) {
-      // 케이스 1: App이 실패 → Playground는 요청 시도 x
+      // 케이스 2: App이 실패 → Playground는 요청 시도 x
       log.error("앱 유저 생성 요청 실패 userId={}", savedUser.getId());
       throw new AuthException(APP_SYNC_FAIL);
     } catch (PlaygroundRequestException | PlaygroundResponseException e) {
-      // 케이스 2: App은 성공했지만 Playground 실패
+      // 케이스 3: App은 성공했지만 Playground 실패
       try {
         appClient.deleteMemberProfile(savedUser.getId());
       } catch (Exception ex) {

--- a/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
+++ b/src/main/java/sopt/makers/authentication/application/service/auth/SignUpService.java
@@ -77,24 +77,24 @@ public class SignUpService implements SignUpUsecase {
     Profile profile = createProfile(targetRegisterInfo);
     Activity activity = createActivity(targetRegisterInfo);
     User newUser = User.createNewUser(socialAccount, profile);
-    User savedUser = userRepository.save(newUser);
+    User savedUser;
+
+    try {
+      savedUser = userRepository.save(newUser);
+    } catch (DataIntegrityViolationException e) {
+      log.error("중복된 소셜 계정으로 회원가입 시도");
+      throw new AuthException(ALREADY_REGISTERED_SOCIAL_ACCOUNT);
+    }
 
     try {
       userActivityHistoryRepository.save(savedUser, activity);
       userRegisterInfoRepository.delete(targetRegisterInfo);
       appClient.createMemberProfile(savedUser.getId());
       playgroundClient.createMemberProfile(savedUser.getId());
-    } catch (DataIntegrityViolationException e) {
-      // 케이스 1: Unique Key 제약 조건 위반 (이미 가입된 소셜 계정)
-      log.error(
-          "중복된 소셜 계정으로 회원가입 시도 authPlatform={}, authPlatformId={}", authPlatform, authPlatformId);
-      throw new AuthException(ALREADY_REGISTERED_SOCIAL_ACCOUNT);
     } catch (AppRequestException | AppResponseException e) {
-      // 케이스 2: App이 실패 → Playground는 요청 시도 x
       log.error("앱 유저 생성 요청 실패 userId={}", savedUser.getId());
       throw new AuthException(APP_SYNC_FAIL);
     } catch (PlaygroundRequestException | PlaygroundResponseException e) {
-      // 케이스 3: App은 성공했지만 Playground 실패
       try {
         appClient.deleteMemberProfile(savedUser.getId());
       } catch (Exception ex) {

--- a/src/main/java/sopt/makers/authentication/domain/auth/exception/AuthFailure.java
+++ b/src/main/java/sopt/makers/authentication/domain/auth/exception/AuthFailure.java
@@ -17,6 +17,7 @@ public enum AuthFailure implements FailureCode {
   INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "ID 토큰 유효성 검사에 실패했습니다."),
   INVALID_PHONE_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
   ALREADY_REGISTER_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 가입된 전화번호입니다."),
+  ALREADY_REGISTERED_SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "이미 가입된 소셜 계정입니다."),
   EXPIRED_PHONE_VERIFICATION(HttpStatus.BAD_REQUEST, "인증 시간이 만료되었습니다."),
 
   // 401


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #256 

## Work Description ✏️
- 회원가입 테스트에서 이미 회원가입을 했었던 소셜 계정을 연동할 경우 500 오류가 발생하여 클라이언트와 서버 간의 소통비용이 증가하고 있기에 이에 대해 400 예외로 처리하도록 로직을 변경했습니다.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
