### PR TITLE
[FIX/#272] 페이징 쿼리 오류 수정 및 캐시 방법 변경

### DIFF
--- a/src/main/java/sopt/makers/authentication/adapter/out/cache/UserCacheRepositoryImpl.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/cache/UserCacheRepositoryImpl.java
@@ -7,14 +7,15 @@ import sopt.makers.authentication.adapter.out.cache.mapper.UserMapper;
 import sopt.makers.authentication.application.port.out.user.UserCacheRepository;
 import sopt.makers.authentication.domain.user.User;
 
-import java.util.HashSet;
+import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
-import org.redisson.api.RMapCache;
+import org.redisson.api.BatchResult;
+import org.redisson.api.RBatch;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.Codec;
 import org.redisson.codec.TypedJsonJacksonCodec;
 import org.springframework.stereotype.Component;
 
@@ -22,31 +23,41 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Component
 public class UserCacheRepositoryImpl implements UserCacheRepository {
-  private static final long TTL_DAYS = 1;
-  private final RMapCache<Long, CachedUserProfile> cache;
+  private static final Duration TTL = Duration.ofDays(1);
+  private static final String KEY_PREFIX = USER_CACHE_NAME + ":";
+
+  private final RedissonClient redissonClient;
   private final UserMapper userMapper;
+  private final Codec codec;
 
   public UserCacheRepositoryImpl(
       RedissonClient redissonClient, UserMapper userMapper, ObjectMapper objectMapper) {
-    this.cache =
-        redissonClient.getMapCache(
-            USER_CACHE_NAME,
-            new TypedJsonJacksonCodec(Long.class, CachedUserProfile.class, objectMapper));
+    this.redissonClient = redissonClient;
     this.userMapper = userMapper;
+    this.codec = new TypedJsonJacksonCodec(CachedUserProfile.class, objectMapper);
   }
 
   @Override
   public Map<Long, User> getAllPresent(List<Long> userIds) {
     if (userIds.isEmpty()) return Map.of();
 
-    Map<Long, CachedUserProfile> cachedProfiles = cache.getAll(new HashSet<>(userIds));
+    RBatch batch = redissonClient.createBatch();
+    userIds.forEach(id -> batch.getBucket(KEY_PREFIX + id, codec).getAsync());
+    BatchResult<?> result = batch.execute();
 
-    return cachedProfiles.entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, e -> userMapper.toDomain(e.getValue())));
+    List<?> responses = result.getResponses();
+    Map<Long, User> users = new HashMap<>();
+    for (int i = 0; i < userIds.size(); i++) {
+      CachedUserProfile profile = (CachedUserProfile) responses.get(i);
+      if (profile != null) {
+        users.put(userIds.get(i), userMapper.toDomain(profile));
+      }
+    }
+    return users;
   }
 
   @Override
   public void put(User user) {
-    cache.put(user.getId(), userMapper.toCache(user), TTL_DAYS, TimeUnit.DAYS);
+    redissonClient.getBucket(KEY_PREFIX + user.getId(), codec).set(userMapper.toCache(user), TTL);
   }
 }

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserJpaRepository.java
@@ -37,18 +37,36 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
   Optional<UserEntity> findWithActivityHistoriesById(@Param("userId") Long userId);
 
   @Query(
-      "SELECT DISTINCT u "
+      "SELECT u.id "
           + "FROM UserEntity u "
-          + "JOIN FETCH u.userActivityHistoryList "
+          + "JOIN u.userActivityHistoryList a "
           + "WHERE (:name IS NULL OR u.name LIKE %:name%) "
-          + "AND EXISTS ("
-          + "SELECT 1 FROM UserActivityHistoryEntity a "
-          + "WHERE a.user = u "
           + "AND (:generation IS NULL OR a.generation = :generation) "
           + "AND (:part IS NULL OR a.part = :part) "
           + "AND (:team IS NULL OR a.team = :team) "
-          + "AND (:isAdmin IS NULL OR :isAdmin = FALSE OR a.role <> 'MEMBER'))")
-  Page<UserEntity> findAllWithActivityHistoriesByGenerationAndPartAndNameAndTeam(
+          + "AND (:isAdmin IS NULL OR :isAdmin = FALSE OR a.role <> 'MEMBER') "
+          + "GROUP BY u.id "
+          + "ORDER BY u.id DESC")
+  Page<Long> findUserIdsOrderByRegisteredDesc(
+      @Param("generation") Integer generation,
+      @Param("part") Part part,
+      @Param("name") String name,
+      @Param("team") Team team,
+      @Param("isAdmin") Boolean isAdmin,
+      Pageable pageable);
+
+  @Query(
+      "SELECT u.id "
+          + "FROM UserEntity u "
+          + "JOIN u.userActivityHistoryList a "
+          + "WHERE (:name IS NULL OR u.name LIKE %:name%) "
+          + "AND (:generation IS NULL OR a.generation = :generation) "
+          + "AND (:part IS NULL OR a.part = :part) "
+          + "AND (:team IS NULL OR a.team = :team) "
+          + "AND (:isAdmin IS NULL OR :isAdmin = FALSE OR a.role <> 'MEMBER') "
+          + "GROUP BY u.id "
+          + "ORDER BY u.id ASC")
+  Page<Long> findUserIdsOrderByRegisteredAsc(
       @Param("generation") Integer generation,
       @Param("part") Part part,
       @Param("name") String name,

--- a/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
+++ b/src/main/java/sopt/makers/authentication/adapter/out/persistence/repository/user/UserRetriever.java
@@ -73,13 +73,10 @@ public class UserRetriever {
     if (orderBy.isGenerationOrder()) {
       return findByGenerationOrder(generation, part, name, team, isAdmin, pageable, orderBy);
     }
-    return userJpaRepository
-        .findAllWithActivityHistoriesByGenerationAndPartAndNameAndTeam(
-            generation, part, name, team, isAdmin, pageable)
-        .map(UserEntity::toDomain);
+    return findByRegisteredOrder(generation, part, name, team, isAdmin, pageable, orderBy);
   }
 
-  private Page<User> findByGenerationOrder(
+  private Page<User> findByRegisteredOrder(
       Integer generation,
       Part part,
       String name,
@@ -88,12 +85,16 @@ public class UserRetriever {
       Pageable pageable,
       UserOrderBy orderBy) {
     Page<Long> userIdPage =
-        orderBy == UserOrderBy.LATEST_GENERATION
-            ? userJpaRepository.findUserIdsOrderByMatchedGenerationDesc(
+        orderBy == UserOrderBy.LATEST_REGISTERED
+            ? userJpaRepository.findUserIdsOrderByRegisteredDesc(
                 generation, part, name, team, isAdmin, pageable)
-            : userJpaRepository.findUserIdsOrderByMatchedGenerationAsc(
+            : userJpaRepository.findUserIdsOrderByRegisteredAsc(
                 generation, part, name, team, isAdmin, pageable);
 
+    return getUsers(pageable, userIdPage);
+  }
+
+  private Page<User> getUsers(Pageable pageable, Page<Long> userIdPage) {
     List<Long> orderedIds = userIdPage.getContent();
     if (orderedIds.isEmpty()) {
       return new PageImpl<>(List.of(), pageable, userIdPage.getTotalElements());
@@ -112,6 +113,24 @@ public class UserRetriever {
         orderedIds.stream().map(userById::get).map(UserEntity::toDomain).toList();
 
     return new PageImpl<>(orderedUsers, pageable, userIdPage.getTotalElements());
+  }
+
+  private Page<User> findByGenerationOrder(
+      Integer generation,
+      Part part,
+      String name,
+      Team team,
+      Boolean isAdmin,
+      Pageable pageable,
+      UserOrderBy orderBy) {
+    Page<Long> userIdPage =
+        orderBy == UserOrderBy.LATEST_GENERATION
+            ? userJpaRepository.findUserIdsOrderByMatchedGenerationDesc(
+                generation, part, name, team, isAdmin, pageable)
+            : userJpaRepository.findUserIdsOrderByMatchedGenerationAsc(
+                generation, part, name, team, isAdmin, pageable);
+
+    return getUsers(pageable, userIdPage);
   }
 
   public int countByGenerationAndIsSopt(int generation, boolean isSopt) {


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #272 

## Work Description ✏️
### HHH90003004 인메모리 페이징 경고 제거
- 원인
  - LATEST_REGISTERED / OLDEST_REGISTERED 정렬 경로에서 1:N Fetch Join과 페이징을 동시에 수행
  - Hibernate는 조인으로 불어난 전체 레코드를 메모리에 올린 뒤 페이징을 적용해서 firstResult/maxResults specified with collection fetch; applying in memory 경고가 발생함
  - 이와 더불어 com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Thread starvation or clock leap detected (housekeeper delta=1m9s695ms392µs587ns) 오류까지 발생함
- 해결
  - 기존에 generation 정렬에서만 사용하던 2-step 방식을 registration 정렬에도 동일하게 적용
  - 1단계 — JOIN + GROUP BY u.id로 유저 ID만 조회 → DB 레벨에서 LIMIT/OFFSET 정상 적용
  - 2단계 — 확정된 ID 목록을 IN 절로 전달해 Fetch Join → 페이징 없이 연관 데이터 로딩
  - 추가된 쿼리: findUserIdsOrderByRegisteredDesc, findUserIdsOrderByRegisteredAsc
  - 제거된 쿼리: findAllWithActivityHistoriesByGenerationAndPartAndNameAndTeam (Fetch Join + 페이징 동시 수행)

### Redis MapCacheEvictionTask 타임아웃 제거
- 원인
  - RMapCache는 per-entry TTL을 구현하기 위해 내부적으로 Sorted Set 3개를 추가로 관리하고, 백그라운드 타이머(MapCacheEvictionTask)가 주기적으로 Lua 스크립트(EVALSHA)를 실행해 만료 항목을 정리함
  - 위의 인메모리 페이징 경고 제거 후 Lua 스크립트 실행이 응답 시간(3000ms)을 초과하면서 RedisResponseTimeoutException이 발생
  - 또한 모든 엔트리의 TTL이 동일하게 1일로 고정되어 있어 RMapCache의 per-entry TTL 기능이 불필요한 상황이라는 점을 확인함
- 해결
  - RMapCache → RBucket per key 방식으로 전환을 선택
  - Redis native TTL(EXPIRE)을 사용하므로 Lua 스크립트 eviction 자체가 없어짐
  - MapCacheEvictionTask가 구조적으로 제거되어 타임아웃 재발 불가
  - 다건 조회(getAllPresent)는 RBatch 파이프라인으로 처리해 네트워크 왕복 최소화
  - 키 구조: user (단일 Map) → user:{userId} (키 per 유저)

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->